### PR TITLE
DEVEX-1686 Fix early database close issue

### DIFF
--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -19,6 +19,8 @@ type downloadCmd struct {
 	gcInfo bool
 }
 
+var err error
+
 const downloadUsage = "dx-download-agent download [-max_threads=N] <manifest.json.bz2>"
 
 func (*downloadCmd) Name() string     { return "download" }

--- a/dxda.go
+++ b/dxda.go
@@ -36,6 +36,8 @@ const (
 	secondsInYear int = 60 * 60 * 24 * 365
 )
 
+var err error
+
 // DXDownloadURL ...
 type DXDownloadURL struct {
 	URL     string            `json:"url"`

--- a/dxda.go
+++ b/dxda.go
@@ -333,9 +333,9 @@ func (st *State) addSymlinkToTable(txn *sql.Tx, slnk DXFileSymlink) {
 func (st *State) CreateManifestDB(manifest Manifest, fname string) {
 	statsFname := fname + ".stats.db?_busy_timeout=60000&cache=shared&mode=rwc"
 	os.Remove(statsFname)
-	db, err := sql.Open("sqlite3", statsFname)
-	check(err)
-	defer db.Close()
+	// db, err := sql.Open("sqlite3", statsFname)
+	// check(err)
+	// defer db.Close()
 
 	sqlStmt := `
 	CREATE TABLE manifest_regular_stats (
@@ -351,7 +351,7 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
                 download_done_time integer
 	);
 	`
-	_, err = db.Exec(sqlStmt)
+	_, err = st.db.Exec(sqlStmt)
 	check(err)
 
 	// symbolic link parts do not have md5 checksums, and they
@@ -370,7 +370,7 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
                 url text
 	);
 	`
-	_, err = db.Exec(sqlStmt)
+	_, err = st.db.Exec(sqlStmt)
 	check(err)
 
 	// create a table for all the symlinks. This is the place
@@ -387,10 +387,10 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
 	        md5     text
 	);
 	`
-	_, err = db.Exec(sqlStmt)
+	_, err = st.db.Exec(sqlStmt)
 	check(err)
 
-	txn, err := db.Begin()
+	txn, err := st.db.Begin()
 	check(err)
 
 	// Regular files

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,9 +1,13 @@
-DXDA_ROOT=/go/src/github.com/dnanexus/dxda
+DXDA_ROOT=/development/dxda
 
-all : correctness benchmark
+all : prep_dx_env correctness benchmark
 
 dxda :
 	go build -o /go/bin/dx-download-agent ${DXDA_ROOT}/cmd/dx-download-agent/dx-download-agent.go
+
+prep_dx_env:
+	dx select dxfuse_test_data
+	dx mkdir -p /applets
 
 correctness: dxda
 	mkdir -p dxda_correctness/resources/usr/bin
@@ -19,7 +23,6 @@ benchmark: dxda
 manifests: correctness_manifest
 
 correctness_manifest:
-	dx select dxfuse_test_data
 	rm -f manifest.json.bz2
 	python ${DXDA_ROOT}/scripts/create_manifest.py -r /correctness
 	mv manifest.json.bz2 correctness.manifest.json.bz2


### PR DESCRIPTION
Found a place where the 'State' object wasn't being used to access the database and could create a premature close.   Tested it with:

```
python run_tests.py --project project-FbZ25gj04J9B8FJ3Gb5fVP41 --test correct --size small --verbose
```