### PR TITLE
DEVEX-1490 symlink downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ After successfully downloading (and optionally inspecting post-download) it shou
 
 ## Additional notes
 
-* Only objects of [class File](https://wiki.dnanexus.com/API-Specification-v1.0.0/Introduction-to-Data-Object-Classes) can be downloaded.
+* Only objects of [class File](https://documentation.dnanexus.com/developer/api/introduction-to-data-object-classes) can be downloaded.

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -15,8 +15,8 @@ import (
 // download subcommand
 type downloadCmd struct {
 	numThreads int
-	verbose bool
-	gcInfo bool
+	verbose    bool
+	gcInfo     bool
 }
 
 var err error
@@ -82,6 +82,7 @@ func (p *downloadCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	// setup a persistent database to track all downloads
 	if _, err := os.Stat(fname + ".stats.db"); os.IsNotExist(err) {
 		fmt.Printf("Creating manifest database %s\n", fname+".stats.db")
+		fmt.Printf("WTF")
 		st.CreateManifestDB(*manifest, fname)
 	}
 
@@ -98,6 +99,7 @@ func (p *downloadCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 
 type progressCmd struct {
 }
+
 func (*progressCmd) Name() string     { return "progress" }
 func (*progressCmd) Synopsis() string { return "show current download progress" }
 
@@ -127,7 +129,7 @@ func (p *progressCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	defer st.Close()
 
 	st.InitDownloadStatus()
-	fmt.Println(st.DownloadProgressOneTime(60*1000*1000*1000))
+	fmt.Println(st.DownloadProgressOneTime(60 * 1000 * 1000 * 1000))
 	return subcommands.ExitSuccess
 }
 
@@ -180,15 +182,14 @@ func (p *inspectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 type versionCmd struct {
 }
 
-func (*versionCmd) Name() string     { return "version" }
-func (*versionCmd) Synopsis() string { return "get the version" }
-func (*versionCmd) Usage() string    { return   "get the dx-download-agent version" }
+func (*versionCmd) Name() string               { return "version" }
+func (*versionCmd) Synopsis() string           { return "get the version" }
+func (*versionCmd) Usage() string              { return "get the dx-download-agent version" }
 func (p *versionCmd) SetFlags(f *flag.FlagSet) {}
 func (p *versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	fmt.Println(dxda.Version)
 	return subcommands.ExitSuccess
 }
-
 
 // The CLI is simply a wrapper around the dxda package
 func main() {

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -82,7 +82,6 @@ func (p *downloadCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	// setup a persistent database to track all downloads
 	if _, err := os.Stat(fname + ".stats.db"); os.IsNotExist(err) {
 		fmt.Printf("Creating manifest database %s\n", fname+".stats.db")
-		fmt.Printf("WTF")
 		st.CreateManifestDB(*manifest, fname)
 	}
 

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -3,6 +3,7 @@ package dxda
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -131,6 +132,7 @@ func submit(
 				MD5:   *descRaw.MD5,
 				Drive: *descRaw.Drive,
 			}
+			fmt.Printf("DRIVE: %s\n", *descRaw.Drive)
 		}
 
 		desc := DxDescribeDataObject{

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -3,7 +3,6 @@ package dxda
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -126,14 +125,12 @@ func submit(
 
 		// If this is a symlink, create structure with
 		// all the relevant information.
-		fmt.Println(descRaw.Id)
 		var symlink *DXSymlink = nil
 		if descRaw.MD5 != nil {
 			symlink = &DXSymlink{
 				MD5:   *descRaw.MD5,
 				Drive: *descRaw.Drive,
 			}
-			fmt.Println("DRIVE: %s\n", *descRaw.Drive)
 		}
 
 		desc := DxDescribeDataObject{

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -126,7 +126,7 @@ func submit(
 		// If this is a symlink, create structure with
 		// all the relevant information.
 		var symlink *DXSymlink = nil
-		if descRaw.MD5 != nil {
+		if descRaw.Drive != nil {
 			symlink = &DXSymlink{
 				MD5:   *descRaw.MD5,
 				Drive: *descRaw.Drive,

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -126,13 +126,14 @@ func submit(
 
 		// If this is a symlink, create structure with
 		// all the relevant information.
+		fmt.Println(descRaw.Id)
 		var symlink *DXSymlink = nil
 		if descRaw.MD5 != nil {
 			symlink = &DXSymlink{
 				MD5:   *descRaw.MD5,
 				Drive: *descRaw.Drive,
 			}
-			fmt.Printf("DRIVE: %s\n", *descRaw.Drive)
+			fmt.Println("DRIVE: %s\n", *descRaw.Drive)
 		}
 
 		desc := DxDescribeDataObject{

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -9,42 +9,42 @@ import (
 // Limit on the number of objects that the bulk-describe API can take
 const (
 	maxNumObjectsInDescribe = 1000
-	numRetriesDefault   = 3
+	numRetriesDefault       = 3
 )
 
 // Description of a DNAx data object
 type DxDescribeDataObject struct {
-	Id             string
-	ProjId         string
-	Name           string
-	State          string
-	ArchivalState  string
-	Folder         string
-	Size           int64
-	Parts          map[string]DXPart // a list of parts for a DNAx file
-	Symlink        *DXSymlink
+	Id            string
+	ProjId        string
+	Name          string
+	State         string
+	ArchivalState string
+	Folder        string
+	Size          int64
+	Parts         map[string]DXPart // a list of parts for a DNAx file
+	Symlink       *DXSymlink
 }
 
 // description of part of a file
 type DXPart struct {
 	// we add the part-id in a post-processing step
-	Id     int
+	Id int
 
 	// these fields are in the input JSON
-	MD5    string `json:"md5"`
-	Size   int    `json:"size"`
+	MD5  string `json:"md5"`
+	Size int    `json:"size"`
 }
 
 // a full URL for symbolic links, with a corresponding MD5 checksum for
 // the entire file.
+// Drive and MD5 of symlnk
 type DXSymlink struct {
-	Url string
-	MD5 string
+	Drive string
+	MD5   string
 }
 
-
 type Request struct {
-	Objects []string `json:"objects"`
+	Objects              []string                              `json:"objects"`
 	ClassDescribeOptions map[string]map[string]map[string]bool `json:"classDescribeOptions"`
 }
 
@@ -57,19 +57,20 @@ type DxDescribeRawTop struct {
 }
 
 type DxSymlinkRaw struct {
-	Url string  `json:"object"`
+	Url string `json:"object"`
 }
 
 type DxDescribeRaw struct {
-	Id               string `json:"id"`
-	ProjId           string `json:"project"`
-	Name             string `json:"name"`
-	State            string `json:"state"`
-	ArchivalState    string `json:"archivalState"`
-	Size             int64 `json:"size"`
-	Parts            map[string]DXPart `json:"parts"`
-	Symlink         *DxSymlinkRaw `json:"symlinkPath,omitempty"`
-	MD5             *string       `json:"md5,omitempty"`
+	Id            string            `json:"id"`
+	ProjId        string            `json:"project"`
+	Name          string            `json:"name"`
+	State         string            `json:"state"`
+	ArchivalState string            `json:"archivalState"`
+	Size          int64             `json:"size"`
+	Parts         map[string]DXPart `json:"parts"`
+	Symlink       *DxSymlinkRaw     `json:"symlinkPath,omitempty"`
+	MD5           *string           `json:"md5,omitempty"`
+	Drive         *string           `json:"drive,omitempty"`
 }
 
 // Describe a large number of file-ids in one API call.
@@ -81,25 +82,25 @@ func submit(
 
 	// Limit the number of fields returned, because by default we
 	// get too much information, which is a burden on the server side.
-	describeOptions := map[string]map[string]map[string]bool {
-		"*" : map[string]map[string]bool {
-			"fields" : map[string]bool {
-				"id" : true,
-				"project" : true,
-				"name" : true,
-				"state" : true,
-				"archivalState" : true,
-				"size" : true,
-				"parts" : true,
-				"symlinkPath" : true,
-				"drive" : true,
-				"md5" : true,
+	describeOptions := map[string]map[string]map[string]bool{
+		"*": map[string]map[string]bool{
+			"fields": map[string]bool{
+				"id":            true,
+				"project":       true,
+				"name":          true,
+				"state":         true,
+				"archivalState": true,
+				"size":          true,
+				"parts":         true,
+				"symlinkPath":   true,
+				"drive":         true,
+				"md5":           true,
 			},
 		},
 	}
 	request := Request{
-		Objects : fileIds,
-		ClassDescribeOptions : describeOptions,
+		Objects:              fileIds,
+		ClassDescribeOptions: describeOptions,
 	}
 	var payload []byte
 	payload, err := json.Marshal(request)
@@ -119,28 +120,28 @@ func submit(
 	}
 
 	var files = make(map[string]DxDescribeDataObject)
-	for _, descRawTop := range(reply.Results) {
+	for _, descRawTop := range reply.Results {
 		descRaw := descRawTop.Describe
 
 		// If this is a symlink, create structure with
 		// all the relevant information.
 		var symlink *DXSymlink = nil
-		if descRaw.Symlink != nil {
+		if descRaw.MD5 != nil {
 			symlink = &DXSymlink{
-				MD5 : *descRaw.MD5,
-				Url : descRaw.Symlink.Url,
+				MD5:   *descRaw.MD5,
+				Drive: *descRaw.Drive,
 			}
 		}
 
 		desc := DxDescribeDataObject{
-			Id :  descRaw.Id,
-			ProjId : descRaw.ProjId,
-			Name : descRaw.Name,
-			State : descRaw.State,
-			ArchivalState : descRaw.ArchivalState,
-			Size : descRaw.Size,
-			Parts : descRaw.Parts,
-			Symlink : symlink,
+			Id:            descRaw.Id,
+			ProjId:        descRaw.ProjId,
+			Name:          descRaw.Name,
+			State:         descRaw.State,
+			ArchivalState: descRaw.ArchivalState,
+			Size:          descRaw.Size,
+			Parts:         descRaw.Parts,
+			Symlink:       symlink,
 		}
 		//fmt.Printf("%v\n", desc)
 		files[desc.Id] = desc
@@ -170,7 +171,7 @@ func DxDescribeBulkObjects(
 	// Don't forget the tail of the requests, that is smaller than the batch size
 	batches = append(batches, objIds)
 
-	for _, objIdBatch := range(batches) {
+	for _, objIdBatch := range batches {
 		m, err := submit(ctx, httpClient, dxEnv, objIdBatch)
 		if err != nil {
 			return nil, err

--- a/dxda.go
+++ b/dxda.go
@@ -13,9 +13,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"path"
 	"runtime"
@@ -23,7 +23,7 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"         // Following canonical example on go-sqlite3 'simple.go'
+	_ "github.com/mattn/go-sqlite3" // Following canonical example on go-sqlite3 'simple.go'
 )
 
 const (
@@ -31,9 +31,9 @@ const (
 	minNumThreads = 2
 	maxNumThreads = 32
 
-	numRetries = 10
-	numRetriesChecksumMismatch = 3
-	secondsInYear int = 60 * 60 * 24 * 365
+	numRetries                     = 10
+	numRetriesChecksumMismatch     = 3
+	secondsInYear              int = 60 * 60 * 24 * 365
 )
 
 var err error
@@ -48,10 +48,12 @@ type DXDownloadURL struct {
 // 1) part of a regular file
 // 2) part of symbolic link (a web address)
 type DBPart interface {
-	folder()   string
+	folder() string
+	fileId() string
 	fileName() string
-	offset()   int64
-	size()     int
+	offset() int64
+	project() string
+	size() int
 }
 
 // Part of a dnanexus file
@@ -67,8 +69,11 @@ type DBPartRegular struct {
 	BytesFetched     int
 	DownloadDoneTime int64 // The time when it completed downloading
 }
+
 func (reg DBPartRegular) folder() string   { return reg.Folder }
 func (reg DBPartRegular) fileName() string { return reg.FileName }
+func (reg DBPartRegular) fileId() string   { return reg.FileId }
+func (reg DBPartRegular) project() string  { return reg.Project }
 func (reg DBPartRegular) offset() int64    { return reg.Offset }
 func (reg DBPartRegular) size() int        { return reg.Size }
 
@@ -87,17 +92,19 @@ type DBPartSymlink struct {
 	DownloadDoneTime int64 // The time when it completed downloading
 	Url              string
 }
+
 func (slnk DBPartSymlink) folder() string   { return slnk.Folder }
 func (slnk DBPartSymlink) fileName() string { return slnk.FileName }
+func (slnk DBPartSymlink) fileId() string   { return slnk.FileId }
+func (slnk DBPartSymlink) project() string  { return slnk.Project }
 func (slnk DBPartSymlink) offset() int64    { return slnk.Offset }
 func (slnk DBPartSymlink) size() int        { return slnk.Size }
 
-
 // JobInfo ...
 type JobInfo struct {
-	part              DBPart
-	url              *DXDownloadURL
-	completeNs        int64
+	part       DBPart
+	url        *DXDownloadURL
+	completeNs int64
 }
 
 // DownloadStatus ...
@@ -116,13 +123,13 @@ type DownloadStatus struct {
 }
 
 type State struct {
-	dxEnv            DXEnvironment
-	opts             Opts
-	mutex            sync.Mutex
+	dxEnv           DXEnvironment
+	opts            Opts
+	mutex           sync.Mutex
 	db              *sql.DB
-	ds              *DownloadStatus  // only the progress report thread accesses this field
-	timeOfLastError  int
-	maxChunkSize     int64
+	ds              *DownloadStatus // only the progress report thread accesses this field
+	timeOfLastError int
+	maxChunkSize    int64
 }
 
 //-----------------------------------------------------------------
@@ -144,7 +151,7 @@ func calcNumThreads(maxChunkSize int64) int {
 	fmt.Printf("number of machine cores: %d\n", numCPUs)
 	fmt.Printf("memory size: %d GiB\n", hwMemoryBytes/GiB)
 
-	numThreads := MinInt(2 * numCPUs, maxNumThreads)
+	numThreads := MinInt(2*numCPUs, maxNumThreads)
 	memoryCostPerThread := 3 * int64(maxChunkSize)
 
 	for numThreads > minNumThreads {
@@ -188,16 +195,16 @@ func NewDxDa(dxEnv DXEnvironment, fname string, optsRaw Opts) *State {
 	// Limit the number of threads
 	fmt.Printf("Downloading files using %d threads\n", opts.NumThreads)
 	fmt.Printf("maximal memory chunk size: %d MiB\n", maxChunkSize/MiB)
-//	runtime.GOMAXPROCS(st.opts.NumThreads + 2)
+	//	runtime.GOMAXPROCS(st.opts.NumThreads + 2)
 
-	return &State {
-		dxEnv : dxEnv,
-		opts : opts,
-		mutex : sync.Mutex{},
-		db : db,
-		ds : nil,
-		timeOfLastError : 0,
-		maxChunkSize : maxChunkSize,
+	return &State{
+		dxEnv:           dxEnv,
+		opts:            opts,
+		mutex:           sync.Mutex{},
+		db:              db,
+		ds:              nil,
+		timeOfLastError: 0,
+		maxChunkSize:    maxChunkSize,
 	}
 }
 
@@ -254,7 +261,7 @@ func (st *State) CheckDiskSpace() error {
 	//
 	totalSizeBytes :=
 		st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_regular_stats WHERE bytes_fetched != size") +
-		st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_symlink_stats WHERE bytes_fetched != size")
+			st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_symlink_stats WHERE bytes_fetched != size")
 
 	// Find how much local disk space is available
 	var stat syscall.Statfs_t
@@ -302,7 +309,7 @@ func (st *State) addSymlinkToTable(txn *sql.Tx, slnk DXFileSymlink) {
 
 	for offset < slnk.Size {
 		// make sure we don't go over the file size
-		endOfs := MinInt64(offset + st.maxChunkSize, slnk.Size)
+		endOfs := MinInt64(offset+st.maxChunkSize, slnk.Size)
 		partLen := endOfs - offset
 
 		if partLen <= 0 {
@@ -328,7 +335,6 @@ func (st *State) addSymlinkToTable(txn *sql.Tx, slnk DXFileSymlink) {
 	_, err := txn.Exec(sqlStmt)
 	check(err)
 }
-
 
 // Read the manifest file, and build a database with an empty state
 // for each part in each file.
@@ -413,7 +419,6 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
 	st.prepareFilesForDownload(manifest)
 }
 
-
 // create an empty file for each download path.
 //
 // TODO: Optimize this for only files that need to be downloaded
@@ -437,10 +442,10 @@ func (st *State) InitDownloadStatus() {
 	// total amounts to download, calculated once
 	numParts :=
 		st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_regular_stats") +
-		st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_symlink_stats")
+			st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_symlink_stats")
 	numBytes :=
 		st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_regular_stats") +
-		st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_symlink_stats")
+			st.queryDBIntegerResult("SELECT SUM(size) FROM manifest_symlink_stats")
 
 	progressIntervalSec := 0
 	if st.dxEnv.DxJobId == "" {
@@ -453,12 +458,12 @@ func (st *State) InitDownloadStatus() {
 	}
 
 	st.ds = &DownloadStatus{
-		NumParts : numParts,
-		NumBytes : numBytes,
-		NumPartsComplete : 0,
-		NumBytesComplete : 0,
-		ProgressInterval : time.Duration(progressIntervalSec) * time.Second,
-		MaxWindowSize : int64(2 * 60 * 1000 * 1000 * 1000),
+		NumParts:         numParts,
+		NumBytes:         numBytes,
+		NumPartsComplete: 0,
+		NumBytesComplete: 0,
+		ProgressInterval: time.Duration(progressIntervalSec) * time.Second,
+		MaxWindowSize:    int64(2 * 60 * 1000 * 1000 * 1000),
 	}
 
 	if st.opts.Verbose {
@@ -506,17 +511,17 @@ func (st *State) DownloadProgressOneTime(timeWindowNanoSec int64) string {
 	// query the current progress
 	st.ds.NumBytesComplete =
 		st.queryDBIntegerResult("SELECT SUM(bytes_fetched) FROM manifest_regular_stats WHERE bytes_fetched = size") +
-		st.queryDBIntegerResult("SELECT SUM(bytes_fetched) FROM manifest_symlink_stats WHERE bytes_fetched = size")
+			st.queryDBIntegerResult("SELECT SUM(bytes_fetched) FROM manifest_symlink_stats WHERE bytes_fetched = size")
 	st.ds.NumPartsComplete =
 		st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_regular_stats WHERE bytes_fetched = size") +
-		st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_symlink_stats WHERE bytes_fetched = size")
+			st.queryDBIntegerResult("SELECT COUNT(*) FROM manifest_symlink_stats WHERE bytes_fetched = size")
 
 	// calculate bandwitdh
 	bandwidthMBSec := st.calcBandwidth(timeWindowNanoSec)
 
 	// report on GC statistics
 	gcReport := ""
-	if (st.opts.GcInfo) {
+	if st.opts.GcInfo {
 		var gcStats runtime.MemStats
 		runtime.ReadMemStats(&gcStats)
 		crntAlloc := int64(gcStats.Alloc)
@@ -601,7 +606,7 @@ func (st *State) downloadSymlinkPart(
 	defer localf.Close()
 
 	headers := make(map[string]string)
-	headers["Range"] = fmt.Sprintf("bytes=%d-%d", p.offset(), p.offset() + int64(p.size()) - 1)
+	headers["Range"] = fmt.Sprintf("bytes=%d-%d", p.offset(), p.offset()+int64(p.size())-1)
 
 	for k, v := range u.Headers {
 		headers[k] = v
@@ -639,7 +644,7 @@ func (st *State) downloadRegPartCheckSum(
 	// loop through the part, reading in chunk pieces
 	endPart := p.Offset + int64(p.Size) - 1
 	for ofs := p.Offset; ofs <= endPart; ofs += st.maxChunkSize {
-		chunkEnd := MinInt64(ofs + st.maxChunkSize - 1, endPart)
+		chunkEnd := MinInt64(ofs+st.maxChunkSize-1, endPart)
 		chunkSize := int(chunkEnd - ofs + 1)
 
 		headers := make(map[string]string)
@@ -676,7 +681,7 @@ func (st *State) downloadRegPart(
 	u DXDownloadURL,
 	memoryBuf []byte) error {
 
-	for i := 0 ; i < numRetriesChecksumMismatch; i++ {
+	for i := 0; i < numRetriesChecksumMismatch; i++ {
 		ok, err := st.downloadRegPartCheckSum(httpClient, p, u, memoryBuf)
 		if err != nil {
 			return err
@@ -692,25 +697,25 @@ func (st *State) downloadRegPart(
 }
 
 // create a download url if one doesn't exist
-func (st *State) createURL(p DBPartRegular, urls map[string]DXDownloadURL, httpClient *http.Client) *DXDownloadURL {
+func (st *State) createURL(p DBPart, urls map[string]DXDownloadURL, httpClient *http.Client) *DXDownloadURL {
 	var u DXDownloadURL
 
 	// check if we already have it
-	u, ok := urls[p.FileId]
+	u, ok := urls[p.fileId()]
 	if ok {
 		return &u
 	}
 
 	// a regular DNAx file. Requires generating a pre-authenticated download URL.
 	payload := fmt.Sprintf("{\"project\": \"%s\", \"duration\": %d}",
-		p.Project, secondsInYear)
+		p.project(), secondsInYear)
 
 	body, err := DxAPI(
 		context.TODO(),
 		httpClient,
 		numRetries,
 		&st.dxEnv,
-		fmt.Sprintf("%s/download", p.FileId),
+		fmt.Sprintf("%s/download", p.fileId()),
 		payload)
 	check(err)
 
@@ -720,13 +725,13 @@ func (st *State) createURL(p DBPartRegular, urls map[string]DXDownloadURL, httpC
 	}
 
 	// record the pre-auth URL so we don't have to create it again
-	urls[p.FileId] = u
+	urls[p.fileId()] = u
 	return &u
 }
 
 // A thread that adds pre-authenticated urls to each jobs.
 //
-func (st *State) preauthUrlsWorker(jobs <- chan JobInfo, jobsWithUrls chan JobInfo) {
+func (st *State) preauthUrlsWorker(jobs <-chan JobInfo, jobsWithUrls chan JobInfo) {
 	httpClient := NewHttpClient()
 	urls := make(map[string]DXDownloadURL)
 
@@ -738,10 +743,11 @@ func (st *State) preauthUrlsWorker(jobs <- chan JobInfo, jobsWithUrls chan JobIn
 
 		case DBPartSymlink:
 			pLnk := j.part.(DBPartSymlink)
-			j.url = &DXDownloadURL{
-				URL : pLnk.Url,
-				Headers : make(map[string]string, 0),
-			}
+			// j.url = &DXDownloadURL{
+			// 	URL : pLnk.Url,
+			// 	Headers : make(map[string]string, 0),
+			// }
+			j.url = st.createURL(pLnk, urls, httpClient)
 		}
 
 		jobsWithUrls <- j
@@ -786,14 +792,14 @@ func (st *State) dbApplyBulkUpdates(completedJobs []JobInfo) {
 	check(err)
 	defer txn.Commit()
 
-	for _, j := range(completedJobs) {
+	for _, j := range completedJobs {
 		st.updateDBPart(txn, j.part, j.completeNs)
 	}
 }
 
 // update the database when a job completes
 // Do this in bulk
-func (st *State) dbUpdateWorker(jobsDbUpdate <- chan JobInfo, wg *sync.WaitGroup) {
+func (st *State) dbUpdateWorker(jobsDbUpdate <-chan JobInfo, wg *sync.WaitGroup) {
 	var accu []JobInfo
 	for j := range jobsDbUpdate {
 		accu = append(accu, j)
@@ -832,8 +838,8 @@ func (st *State) DownloadManifestDB(fname string) {
 			&p.Size, &p.MD5, &p.BytesFetched, &p.DownloadDoneTime)
 		check(err)
 		j := JobInfo{
-			part : p,
-			url : nil,
+			part: p,
+			url:  nil,
 		}
 		jobs <- j
 		numRows++
@@ -852,9 +858,9 @@ func (st *State) DownloadManifestDB(fname string) {
 		err = rows.Scan(&p.FileId, &p.Project, &p.FileName, &p.Folder, &p.PartId, &p.Offset,
 			&p.Size, &p.BytesFetched, &p.DownloadDoneTime, &p.Url)
 		check(err)
-		j := JobInfo {
-			part : p,
-			url : nil,
+		j := JobInfo{
+			part: p,
+			url:  nil,
 		}
 		jobs <- j
 	}
@@ -900,7 +906,6 @@ func (st *State) DownloadManifestDB(fname string) {
 	PrintLogAndOut("Download completed successfully.\n")
 	PrintLogAndOut("To perform additional post-download integrity checks, please use the 'inspect' subcommand.\n")
 }
-
 
 // UpdateDBPart.
 func (st *State) updateDBPart(txn *sql.Tx, p DBPart, tsNanoSec int64) {
@@ -981,7 +986,6 @@ func (st *State) resetSymlinkFile(slnk DXFileSymlink) {
 	check(err)
 }
 
-
 // -----------------------------------------
 // inspect: validation of downloaded parts
 
@@ -1038,7 +1042,6 @@ func (st *State) filePartIntegrityWorker(id int, jobs <-chan JobInfo, integrityM
 	}
 	wg.Done()
 }
-
 
 func (st *State) validateSymlinkChecksum(f DXFileSymlink, integrityMsgs chan string) {
 	fname := fmt.Sprintf(".%s/%s", f.Folder, f.Name)
@@ -1103,7 +1106,7 @@ func (st *State) checkAllRegularFileIntegrity() bool {
 			&p.Size, &p.MD5, &p.BytesFetched, &p.DownloadDoneTime)
 		check(err)
 		j := JobInfo{
-			part : p,
+			part: p,
 		}
 		jobs <- j
 	}
@@ -1160,7 +1163,7 @@ func (st *State) checkAllSymlinkIntegrity() bool {
 
 	// skip files that weren't entirely downloaded
 	var completed []DXFileSymlink
-	for _, slnk := range(allSymlinks) {
+	for _, slnk := range allSymlinks {
 		numBytesComplete := st.queryDBIntegerResult(
 			fmt.Sprintf("SELECT SUM(bytes_fetched) FROM manifest_symlink_stats WHERE file_id = '%s'",
 				slnk.Id))
@@ -1182,7 +1185,7 @@ func (st *State) checkAllSymlinkIntegrity() bool {
 
 	// Create a job to verify all of the symlinks.
 	//
-	for _, slnk := range(completed) {
+	for _, slnk := range completed {
 		if st.opts.Verbose {
 			fmt.Printf("Checking symlink %s\n", slnk.Url)
 		}

--- a/dxda.go
+++ b/dxda.go
@@ -405,6 +405,8 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
 	for _, f := range manifest.Files {
 		switch f.(type) {
 		case DXFileRegular:
+			fmt.Println("Regular file")
+			fmt.Println(DXFileRegular.id)
 			st.addRegularFileToTable(txn, f.(DXFileRegular))
 		case DXFileSymlink:
 			st.addSymlinkToTable(txn, f.(DXFileSymlink))

--- a/dxda.go
+++ b/dxda.go
@@ -405,8 +405,6 @@ func (st *State) CreateManifestDB(manifest Manifest, fname string) {
 	for _, f := range manifest.Files {
 		switch f.(type) {
 		case DXFileRegular:
-			fmt.Println("Regular file")
-			fmt.Println(DXFileRegular.id)
 			st.addRegularFileToTable(txn, f.(DXFileRegular))
 		case DXFileSymlink:
 			st.addSymlinkToTable(txn, f.(DXFileSymlink))

--- a/manifest.go
+++ b/manifest.go
@@ -52,7 +52,6 @@ type DXFileSymlink struct {
 	ProjId string
 	Name   string
 	Size   int64
-	Url    string
 	MD5    string
 }
 
@@ -251,7 +250,6 @@ func (mRaw ManifestRaw) makeValidatedManifest(ctx context.Context, dxEnv *DXEnvi
 					ProjId: projId,
 					Name:   f.Name,
 					Size:   fDesc.Size,
-					Url:    "",
 					MD5:    fDesc.Symlink.MD5,
 				}
 				manifest.Files = append(manifest.Files, dxSymlink)

--- a/manifest.go
+++ b/manifest.go
@@ -203,6 +203,7 @@ func (mRaw ManifestRaw) makeValidatedManifest(ctx context.Context, dxEnv *DXEnvi
 		}
 	}
 
+	fmt.Print("Validating manifest")
 	// describe all the files
 	dataObjs, err := DxDescribeBulkObjects(ctx, tmpHttpClient, dxEnv, fileIds)
 	if err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -203,7 +203,6 @@ func (mRaw ManifestRaw) makeValidatedManifest(ctx context.Context, dxEnv *DXEnvi
 		}
 	}
 
-	fmt.Print("Validating manifest")
 	// describe all the files
 	dataObjs, err := DxDescribeBulkObjects(ctx, tmpHttpClient, dxEnv, fileIds)
 	if err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -20,25 +20,25 @@ import (
 //  1) a map from file-id to a description of a regular file
 //  2) a map from file-id to a description of a symbolic link
 type Manifest struct {
-	Files     []DXFile
+	Files []DXFile
 }
 
 // one interface representing both symbolic links and data files
 type DXFile interface {
-	id()          string
-	projId()      string
-	folder()      string
-	name()        string
+	id() string
+	projId() string
+	folder() string
+	name() string
 }
 
 // Data file on dnanexus
 type DXFileRegular struct {
-	Folder        string
-	Id            string
-	ProjId        string
-	Name          string
-	Size          int64
-	Parts         []DXPart
+	Folder string
+	Id     string
+	ProjId string
+	Name   string
+	Size   int64
+	Parts  []DXPart
 }
 
 func (reg DXFileRegular) id() string     { return reg.Id }
@@ -46,15 +46,14 @@ func (reg DXFileRegular) projId() string { return reg.ProjId }
 func (reg DXFileRegular) folder() string { return reg.Folder }
 func (reg DXFileRegular) name() string   { return reg.Name }
 
-
 type DXFileSymlink struct {
-	Folder        string
-	Id            string
-	ProjId        string
-	Name          string
-	Size          int64
-	Url           string
-	MD5           string
+	Folder string
+	Id     string
+	ProjId string
+	Name   string
+	Size   int64
+	Url    string
+	MD5    string
 }
 
 func (slnk DXFileSymlink) id() string     { return slnk.Id }
@@ -73,10 +72,10 @@ type ManifestRaw map[string][]ManifestRawFile
 // File description in the manifest. Additional details will be gathered
 // with an API call.
 type ManifestRawFile struct {
-	Folder        string            `json:"folder"`
-	Id            string            `json:"id"`
-	Name          string            `json:"name"`
-	Parts        *map[string]DXPart `json:"parts,omitempty"`
+	Folder string             `json:"folder"`
+	Id     string             `json:"id"`
+	Name   string             `json:"name"`
+	Parts  *map[string]DXPart `json:"parts,omitempty"`
 }
 
 func validateDirName(p string) error {
@@ -144,9 +143,9 @@ func processFileParts(orgParts map[string]DXPart) []DXPart {
 	var parts []DXPart
 	for partId, p := range orgParts {
 		p2 := DXPart{
-			Id :   safeString2Int(partId),
-			MD5 :  p.MD5,
-			Size : p.Size,
+			Id:   safeString2Int(partId),
+			MD5:  p.MD5,
+			Size: p.Size,
 		}
 		parts = append(parts, p2)
 	}
@@ -159,7 +158,7 @@ func processFileParts(orgParts map[string]DXPart) []DXPart {
 
 func (mRaw ManifestRaw) genTrustedManifest() (*Manifest, error) {
 	manifest := Manifest{
-		Files : make([]DXFile, 0),
+		Files: make([]DXFile, 0),
 	}
 
 	// fill in the missing information
@@ -171,18 +170,18 @@ func (mRaw ManifestRaw) genTrustedManifest() (*Manifest, error) {
 
 			// calculate file size by summing up the parts
 			size := int64(0)
-			for _, p := range(parts) {
+			for _, p := range parts {
 				size += int64(p.Size)
 			}
 
 			// regular file
 			dxFile := DXFileRegular{
-				Folder : folder,
-				Id : f.Id,
-				ProjId : projId,
-				Name : f.Name,
-				Size : size,
-				Parts : parts,
+				Folder: folder,
+				Id:     f.Id,
+				ProjId: projId,
+				Name:   f.Name,
+				Size:   size,
+				Parts:  parts,
 			}
 			manifest.Files = append(manifest.Files, dxFile)
 		}
@@ -190,7 +189,6 @@ func (mRaw ManifestRaw) genTrustedManifest() (*Manifest, error) {
 
 	return &manifest, nil
 }
-
 
 // Fill in missing fields for each file. Split into symlinks, and regular files.
 //
@@ -212,7 +210,7 @@ func (mRaw ManifestRaw) makeValidatedManifest(ctx context.Context, dxEnv *DXEnvi
 	}
 
 	manifest := Manifest{
-		Files : make([]DXFile, 0),
+		Files: make([]DXFile, 0),
 	}
 
 	// fill in the missing information
@@ -237,24 +235,24 @@ func (mRaw ManifestRaw) makeValidatedManifest(ctx context.Context, dxEnv *DXEnvi
 			if fDesc.Symlink == nil {
 				// regular file
 				dxFile := DXFileRegular{
-					Folder : folder,
-					Id : f.Id,
-					ProjId : projId,
-					Name : f.Name,
-					Size : fDesc.Size,
-					Parts : processFileParts(fDesc.Parts),
+					Folder: folder,
+					Id:     f.Id,
+					ProjId: projId,
+					Name:   f.Name,
+					Size:   fDesc.Size,
+					Parts:  processFileParts(fDesc.Parts),
 				}
 				manifest.Files = append(manifest.Files, dxFile)
 			} else {
 				// symbolic link
 				dxSymlink := DXFileSymlink{
-					Folder : folder,
-					Id : f.Id,
-					ProjId : projId,
-					Name : f.Name,
-					Size : fDesc.Size,
-					Url : fDesc.Symlink.Url,
-					MD5 : fDesc.Symlink.MD5,
+					Folder: folder,
+					Id:     f.Id,
+					ProjId: projId,
+					Name:   f.Name,
+					Size:   fDesc.Size,
+					Url:    "",
+					MD5:    fDesc.Symlink.MD5,
 				}
 				manifest.Files = append(manifest.Files, dxSymlink)
 			}

--- a/scripts/create_manifest.py
+++ b/scripts/create_manifest.py
@@ -22,7 +22,9 @@ def fileID2manifest(fdetails, project):
     pruned['id'] = fdetails['id']
     pruned['name'] = fdetails['name']
     pruned['folder'] = fdetails['folder']
-    pruned['parts'] = {pid: {k:v for k,v in pdetails.items() if k == "md5" or k == "size"} for pid, pdetails in fdetails['parts'].items()}
+    # Symlinks do not contain parts
+    if fdetails['parts']:
+      pruned['parts'] = {pid: {k:v for k,v in pdetails.items() if k == "md5" or k == "size"} for pid, pdetails in fdetails['parts'].items()}
     return pruned
 
 def generate_manifest_file(folder, project, outfile, recursive):

--- a/util.go
+++ b/util.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	KiB                   = 1024
-	MiB                   = 1024 * KiB
-	GiB                   = 1024 * MiB
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
 )
 const (
 	// Limit on an http request to S3/Azure object storage
@@ -28,24 +28,24 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.3.0"
+	Version = "v0.3.1"
 )
 
 // Configuration options for the download agent
 type Opts struct {
-	NumThreads int   // number of workers to process downloads
-	Verbose    bool  // verbose logging
-	GcInfo     bool  // Garbage collection statistics
+	NumThreads int  // number of workers to process downloads
+	Verbose    bool // verbose logging
+	GcInfo     bool // Garbage collection statistics
 }
 
 // A subset of the configuration parameters that the dx-toolkit uses.
 //
 type DXEnvironment struct {
-	ApiServerHost      string `json:"apiServerHost"`
-	ApiServerPort      int    `json:"apiServerPort"`
-	ApiServerProtocol  string `json:"apiServerProtocol"`
-	Token              string `json:"token"`
-	DxJobId            string `json:"dxJobId"`
+	ApiServerHost     string `json:"apiServerHost"`
+	ApiServerPort     int    `json:"apiServerPort"`
+	ApiServerProtocol string `json:"apiServerProtocol"`
+	Token             string `json:"token"`
+	DxJobId           string `json:"dxJobId"`
 }
 
 // DXConfig - Basic variables regarding DNAnexus environment config
@@ -86,7 +86,7 @@ func GetDxEnvironment() (DXEnvironment, string, error) {
 	obtainedBy := ""
 
 	// start with hardcoded defaults
-	crntDxEnv := DXEnvironment{ "api.dnanexus.com", 443, "https", "", "" }
+	crntDxEnv := DXEnvironment{"api.dnanexus.com", 443, "https", "", ""}
 
 	// override by environment variables, if they are set
 	apiServerHost := os.Getenv("DX_APISERVER_HOST")
@@ -160,10 +160,10 @@ func MinInt(x, y int) int {
 }
 
 func MinInt64(x, y int64) int64 {
-    if x > y {
-        return y
-    }
-    return x
+	if x > y {
+		return y
+	}
+	return x
 }
 
 func safeString2Int(s string) int {


### PR DESCRIPTION
Create pre-auth URL for both regular and symlink files. Check that file is symlink by `"drive"` describe output, `"symlinkPath"` is only in the describe output for the user who created the object. 

Fix manifest generation for symlinks by removing an empty parts dict.