### PR TITLE
Do not attempt to close resp body if err

### DIFF
--- a/dx_http.go
+++ b/dx_http.go
@@ -228,9 +228,6 @@ func dxHttpRequestCore(
 
 	resp, err := client.Do(req)
 	if err != nil {
-		// read the response body so we can reuse this connection.
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Pancis when `resp` is nil.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x71748d]
goroutine 46 [running]:
github.com/dnanexus/dxda.dxHttpRequestCore(0x9271e0, 0xc000336540, 0xc0004a0030, 0x8a0287, 0x3, 0xc0000e25a0, 0x5b, 0xc0002c5848, 0xc000308638, 0x2, ...)
/go/src/github.com/dnanexus/dxda/dx_http.go:232 +0x4cd
github.com/dnanexus/dxda.DxHttpRequest(0x9271e0, 0xc000336540, 0xc0004a0030, 0xa, 0x8a0287, 0x3, 0xc0000e25a0, 0x5b, 0xc0002c5848, 0xc000308638, ...)
/go/src/github.com/dnanexus/dxda/dx_http.go:276 +0x103
github.com/dnanexus/dxda.DxHttpRequestData(0x927220, 0xc00001e050, 0xc0004a0030, 0x8a0287, 0x3, 0xc0000e25a0, 0x5b, 0xc0002c5848, 0xc000308638, 0x2, ...)
/go/src/github.com/dnanexus/dxda/dx_http.go:328 +0x28b
github.com/dnanexus/dxda.(*State).downloadRegPartCheckSum(0xc0000d2100, 0xc0004a0030, 0xc000573760, 0x1d, 0xc000573780, 0x20, 0xc0005048c0, 0x32, 0xc0005737a0, 0x15, ...)
/go/src/github.com/dnanexus/dxda/dxda.go:653 +0x420
github.com/dnanexus/dxda.(*State).downloadRegPart(0xc0000d2100, 0xc0004a0030, 0xc000573760, 0x1d, 0xc000573780, 0x20, 0xc0005048c0, 0x32, 0xc0005737a0, 0x15, ...)
/go/src/github.com/dnanexus/dxda/dxda.go:682 +0x16e
github.com/dnanexus/dxda.(*State).worker(0xc0000d2100, 0x7, 0xc0000e4900, 0xc0000e4960, 0xc0006842c0)
/go/src/github.com/dnanexus/dxda/dxda.go:763 +0x2dd
created by github.com/dnanexus/dxda.(*State).DownloadManifestDB
/go/src/github.com/dnanexus/dxda/dxda.go:880 +0x80d
```