### PR TITLE
DEVEX-996 Windows compatibility

### DIFF
--- a/available_bytes.go
+++ b/available_bytes.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package dxda
+
+import "syscall"
+
+func getAvailableBytes(wd string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(wd, &stat); err != nil {
+		return 0, err
+	}
+	// Available blocks * size per block = available space in bytes
+	availableBytes := int64(stat.Bavail) * int64(stat.Bsize)
+	return availableBytes, nil
+}

--- a/available_bytes_windows.go
+++ b/available_bytes_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package dxda
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func getAvailableBytes(wd string) (int64, error) {
+	h := syscall.MustLoadDLL("kernel32.dll")
+	c := h.MustFindProc("GetDiskFreeSpaceExW")
+
+	var availableBytes int64
+	var totalBytes int64
+	var freeBytes int64
+
+	c.Call(
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(wd))),
+		uintptr(unsafe.Pointer(&freeBytes)),
+		uintptr(unsafe.Pointer(&totalBytes)),
+		uintptr(unsafe.Pointer(&availableBytes)))
+
+	return availableBytes, nil
+}

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -32,3 +32,10 @@ In order to test on the local machine, not on the cloud, go to directory `test/l
 | ----                   |  ---                                   | ---        | ---             |
 | `regular_file_test.sh` | small scale test for regular files     | 138 MB | 559 |
 | `symlink_test.sh`      | test with five moderate sized symlinks | 98 MB | 10 |
+
+# Cross-platform compilation
+
+Ubuntu 16.04 requires two additional apt packages for Windows compilation. 
+`gcc-multilib gcc-mingw-w64`
+The following build flags are also required to properly compile go-sqlite3.
+`env GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++`

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.4.1"
+	Version = "v0.5.1"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Windows compatibility and build. Two fixes required were splitting out getting the usable space on disk and concatenating filepaths. Did a basic sanity test on Windows 10 to download a 500MB manifest successfully, but nothing thorough. 