### PR TITLE
DEVEX-1788 Retry 10 times for describe calls

### DIFF
--- a/dx_describe.go
+++ b/dx_describe.go
@@ -9,7 +9,7 @@ import (
 // Limit on the number of objects that the bulk-describe API can take
 const (
 	maxNumObjectsInDescribe = 1000
-	numRetriesDefault       = 3
+	numRetriesDefault       = 10
 )
 
 // Description of a DNAx data object
@@ -110,6 +110,7 @@ func submit(
 	//fmt.Printf("payload = %s", string(payload))
 
 	repJs, err := DxAPI(ctx, httpClient, numRetriesDefault, dxEnv, "system/describeDataObjects", string(payload))
+
 	if err != nil {
 		return nil, err
 	}

--- a/dx_http.go
+++ b/dx_http.go
@@ -263,14 +263,14 @@ func DxHttpRequest(
 	attemptTimeout := attemptTimeoutInit
 	var tCnt int
 	var err error
-	for tCnt = 0; tCnt < numRetries; tCnt++ {
+	for tCnt = 0; tCnt <= numRetries; tCnt++ {
 		if tCnt > 0 {
 			// sleep before retrying. Use bounded exponential backoff.
 			time.Sleep(time.Duration(attemptTimeout) * time.Second)
 			attemptTimeout = MinInt(2*attemptTimeout, attemptTimeoutMax)
 		}
-
-		response, err := dxHttpRequestCore(ctx, client, requestType, url, headers, data)
+		var response *http.Response
+		response, err = dxHttpRequestCore(ctx, client, requestType, url, headers, data)
 		if err == nil {
 			// http request went well, return the body
 			return response, nil
@@ -293,7 +293,6 @@ func DxHttpRequest(
 			return nil, err
 		}
 	}
-
 	log.Printf("%s request to '%s' failed after %d attempts, err=%s",
 		requestType, url, tCnt, err.Error())
 	return nil, err

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ const (
 
 	// An API request to the dnanexus servers should never take more
 	// than this amount of time
-	dxApiOverallTimout = 2 * time.Minute
+	dxApiOverallTimout = 5 * time.Minute
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.1"
+	Version = "v0.5.2"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Bump retry default to 10 calls for object describe api calls. Fix error logging for request failures. 
