### PR TITLE
DEVEX-1793 Skip file-xxxx/download call optimization

### DIFF
--- a/dx_describe.go
+++ b/dx_describe.go
@@ -3,7 +3,6 @@ package dxda
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 )
@@ -132,7 +131,7 @@ func submit(
 		}
 	}
 
-	fmt.Printf("payload = %s", string(payload))
+	//fmt.Printf("payload = %s", string(payload))
 
 	repJs, err := DxAPI(ctx, httpClient, numRetriesDefault, dxEnv, "system/findDataObjects", string(payload))
 

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -3,7 +3,9 @@ package dxda
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 )
 
 // Limit on the number of objects that the bulk-describe API can take
@@ -44,8 +46,14 @@ type DXSymlink struct {
 }
 
 type Request struct {
-	Objects              []string                              `json:"objects"`
-	ClassDescribeOptions map[string]map[string]map[string]bool `json:"classDescribeOptions"`
+	Objects         []string                   `json:"objects"`
+	DescribeOptions map[string]map[string]bool `json:"describe"`
+}
+
+type RequestWithScope struct {
+	Objects         []string                   `json:"id"`
+	Scope           map[string]string          `json:"scope"`
+	DescribeOptions map[string]map[string]bool `json:"describe"`
 }
 
 type Reply struct {
@@ -78,38 +86,55 @@ func submit(
 	ctx context.Context,
 	httpClient *http.Client,
 	dxEnv *DXEnvironment,
+	projectId string,
 	fileIds []string) (map[string]DxDescribeDataObject, error) {
 
 	// Limit the number of fields returned, because by default we
 	// get too much information, which is a burden on the server side.
-	describeOptions := map[string]map[string]map[string]bool{
-		"*": map[string]map[string]bool{
-			"fields": map[string]bool{
-				"id":            true,
-				"project":       true,
-				"name":          true,
-				"state":         true,
-				"archivalState": true,
-				"size":          true,
-				"parts":         true,
-				"symlinkPath":   true,
-				"drive":         true,
-				"md5":           true,
-			},
+
+	describeOptions := map[string]map[string]bool{
+		"fields": map[string]bool{
+			"id":            true,
+			"project":       true,
+			"name":          true,
+			"state":         true,
+			"archivalState": true,
+			"size":          true,
+			"parts":         true,
+			"symlinkPath":   true,
+			"drive":         true,
+			"md5":           true,
 		},
 	}
-	request := Request{
-		Objects:              fileIds,
-		ClassDescribeOptions: describeOptions,
-	}
 	var payload []byte
-	payload, err := json.Marshal(request)
-	if err != nil {
-		return nil, err
+	// If given a valid project or container provide the scope parameter to reduce load on the backend
+	if strings.HasPrefix(projectId, "project-") || strings.HasPrefix(projectId, "container-") {
+		scope := map[string]string{
+			"project": projectId,
+		}
+		request := RequestWithScope{
+			Objects:         fileIds,
+			Scope:           scope,
+			DescribeOptions: describeOptions,
+		}
+		payload, err = json.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		request := Request{
+			Objects:         fileIds,
+			DescribeOptions: describeOptions,
+		}
+		payload, err = json.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
 	}
-	//fmt.Printf("payload = %s", string(payload))
 
-	repJs, err := DxAPI(ctx, httpClient, numRetriesDefault, dxEnv, "system/describeDataObjects", string(payload))
+	fmt.Printf("payload = %s", string(payload))
+
+	repJs, err := DxAPI(ctx, httpClient, numRetriesDefault, dxEnv, "system/findDataObjects", string(payload))
 
 	if err != nil {
 		return nil, err
@@ -123,7 +148,6 @@ func submit(
 	var files = make(map[string]DxDescribeDataObject)
 	for _, descRawTop := range reply.Results {
 		descRaw := descRawTop.Describe
-
 		// If this is a symlink, create structure with
 		// all the relevant information.
 		var symlink *DXSymlink = nil
@@ -154,6 +178,7 @@ func DxDescribeBulkObjects(
 	ctx context.Context,
 	httpClient *http.Client,
 	dxEnv *DXEnvironment,
+	projectId string,
 	objIds []string) (map[string]DxDescribeDataObject, error) {
 	var gMap = make(map[string]DxDescribeDataObject)
 	if len(objIds) == 0 {
@@ -173,7 +198,7 @@ func DxDescribeBulkObjects(
 	batches = append(batches, objIds)
 
 	for _, objIdBatch := range batches {
-		m, err := submit(ctx, httpClient, dxEnv, objIdBatch)
+		m, err := submit(ctx, httpClient, dxEnv, projectId, objIdBatch)
 		if err != nil {
 			return nil, err
 		}

--- a/dx_http.go
+++ b/dx_http.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	maxRetryCount      = 10
-	userAgent          = "dxda: DNAnexus download agent"
+	userAgent          = "dxda: DNAnexus download agent " + Version
 	reqTimeout         = 15  // seconds
 	attemptTimeoutInit = 2   // seconds
 	attemptTimeoutMax  = 600 // seconds

--- a/dxda.go
+++ b/dxda.go
@@ -737,7 +737,8 @@ func (st *State) preauthUrlsWorker(jobs <-chan JobInfo, jobsWithUrls chan JobInf
 		switch j.part.(type) {
 		case DBPartRegular:
 			p := j.part.(DBPartRegular)
-			j.url = st.createURL(p, urls, httpClient)
+			j.url = "http://10.0.3.1:8090/F/D2PRJ/" + p.fileId() + "/" + p.project()
+			//j.url = st.createURL(p, urls, httpClient)
 
 		case DBPartSymlink:
 			pLnk := j.part.(DBPartSymlink)

--- a/dxda.go
+++ b/dxda.go
@@ -729,7 +729,7 @@ func (st *State) createURL(p DBPart, urls map[string]DXDownloadURL, httpClient *
 
 // A thread that adds pre-authenticated urls to each jobs.
 //
-func (st *State) preauthUrlsWorker(jobs <-chan JobInfo, jobsWithUrls chan JobInfo) {
+func (st *State) preauthUrlsWorker(jobs <-chan JobInfo, jobsWithUrls chan JobInfo, dxEnv *DXEnvironment) {
 	httpClient := NewHttpClient()
 	urls := make(map[string]DXDownloadURL)
 
@@ -737,9 +737,18 @@ func (st *State) preauthUrlsWorker(jobs <-chan JobInfo, jobsWithUrls chan JobInf
 		switch j.part.(type) {
 		case DBPartRegular:
 			p := j.part.(DBPartRegular)
-			j.url = "http://10.0.3.1:8090/F/D2PRJ/" + p.fileId() + "/" + p.project()
-			//j.url = st.createURL(p, urls, httpClient)
-
+			// If running in a job and a download URI has been set in the execution environment
+			// skip file-xxxx/download call to reduce system load
+			if dxEnv.DxJobId != "" && os.Getenv("DX_DXDA_DOWNLOAD_URI") != "" {
+				var u DXDownloadURL
+				u.URL = os.Getenv("DX_DXDA_DOWNLOAD_URI") + p.fileId() + "/" + p.project()
+				headers := make(map[string]string)
+				headers["X-Authorization"] = dxEnv.Token
+				u.Headers = headers
+				j.url = &u
+			} else {
+				j.url = st.createURL(p, urls, httpClient)
+			}
 		case DBPartSymlink:
 			pLnk := j.part.(DBPartSymlink)
 			j.url = st.createURL(pLnk, urls, httpClient)
@@ -866,7 +875,7 @@ func (st *State) DownloadManifestDB(fname string) {
 
 	// the preauth thread adds a valid URL to each job.
 	jobsWithUrls := make(chan JobInfo, totNumJobs)
-	go st.preauthUrlsWorker(jobs, jobsWithUrls)
+	go st.preauthUrlsWorker(jobs, jobsWithUrls, &st.dxEnv)
 
 	// the db-update thread updates the database when jobs
 	// complete.

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.2"
+	Version = "v0.5.3"
 )
 
 // Configuration options for the download agent

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ const (
 
 	// An API request to the dnanexus servers should never take more
 	// than this amount of time
-	dxApiOverallTimout = 5 * time.Minute
+	dxApiOverallTimout = 10 * time.Minute
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX


### PR DESCRIPTION
If running inside a job, look for `DX_DXDA_DOWNLOAD_URI` set in the execution environment. If set, skip the `file-xxxx/download` call and append the file-id and project-id. 
Also move to optimized `/system/findDataObjects` route with project-id specified for looking up part information per file-id. Should help with getting parts for 1000s of files. 