### PR TITLE
Fix inspect where file is missing

### DIFF
--- a/dxda.go
+++ b/dxda.go
@@ -956,7 +956,9 @@ func (st *State) resetRegularFile(p DBPartRegular) {
 	folder := filepath.Join(wd, p.Folder)
 	fname := filepath.Join(folder, p.FileName)
 	err = os.Truncate(fname, 0)
-	check(err)
+	if !os.IsNotExist(err) {
+		check(err)
+	}
 
 	st.mutex.Lock()
 	defer st.mutex.Unlock()
@@ -980,8 +982,9 @@ func (st *State) resetSymlinkFile(slnk DXFileSymlink) {
 	folder := filepath.Join(wd, slnk.Folder)
 	fname := filepath.Join(folder, slnk.Name)
 	err = os.Truncate(fname, 0)
-	check(err)
-
+	if !os.IsNotExist(err) {
+		check(err)
+	}
 	st.mutex.Lock()
 	defer st.mutex.Unlock()
 

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.4"
+	Version = "v0.5.5"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Ignore failure for file not found when truncating during `dx-download-agent inspect`. Reported in https://github.com/dnanexus/dxda/issues/55

Bump version to v0.5.5