### PR TITLE
DEVEX-1960 Retry 502 outside of dnanexus job env

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: Build Macos executable
           run: |
             set -x
@@ -52,7 +52,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: go dependencies
           run: go get -u github.com/google/subcommands
         - name: Build Windows executable
@@ -84,7 +84,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: apt-get dependencies
           run: sudo apt-get install -y build-essential
         - name: Build Linux executable

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -17,7 +17,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: Build Macos executable
           run: |
             set -x
@@ -35,7 +35,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: Build Windows executable
           run: |
             go build -o dx-download-agent.exe cmd/dx-download-agent/dx-download-agent.go
@@ -51,7 +51,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '^1.14.2'
+            go-version: '1.16.6'
         - name: apt-get dependencies
           run: sudo apt-get install -y build-essential
         - name: Build Linux executable

--- a/dx_http.go
+++ b/dx_http.go
@@ -131,7 +131,7 @@ func isRetryable(ctx context.Context, requestType string, status int) bool {
 	// Bad gateway
 	// Sometimes caused by s3 closing the connection to the worker's
 	// download proxy. Retryable inside a job.
-	if status == 502 && os.Getenv("DX_JOB_ID") != "" {
+	if status == 502 {
 		return true
 	}
 

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.6"
+	Version = "v0.5.7"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Retry 502 in all contexts.

Bump to golang 1.16.6.

Bump version to v0.5.7