### PR TITLE
DEVEX-1996 Make UserAgent global var

### DIFF
--- a/dx_http.go
+++ b/dx_http.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -23,7 +24,6 @@ import (
 
 const (
 	maxRetryCount      = 10
-	userAgent          = "dxda: DNAnexus download agent " + Version
 	reqTimeout         = 15  // seconds
 	attemptTimeoutInit = 2   // seconds
 	attemptTimeoutMax  = 600 // seconds
@@ -34,6 +34,9 @@ const (
 	badLengthTimeout    = 5 // seconds
 	badLengthNumRetries = 10
 )
+
+// example 'dxda/v0.1.2 (linux)
+var UserAgent = fmt.Sprintf("dxda/%s (%s)", Version, runtime.GOOS)
 
 type HttpError struct {
 	Message             []byte

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.7"
+	Version = "v0.5.8"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Change `user-agent` from const to global var to allow dxfuse to provide its own user-agent string.

Change format of `user-agent` header to be in line with dx-toolkit. 

Bump to v0.5.8 for release.