### PR TITLE
DEVEX-2148 split_manifest.py: Read/write compressed files in binary mode.

### DIFF
--- a/scripts/split_manifest.py
+++ b/scripts/split_manifest.py
@@ -9,14 +9,14 @@ def chunks(l, n):
         yield l[i:i + n]
 
 def split_manifest(manifest_file, num_files):
-    with open(manifest_file) as mf:
+    with open(manifest_file, "rb") as mf:
         manifest = json.loads(bz2.decompress(mf.read()))
         for project, file_list in manifest.items():
             for i, file_subset in enumerate(chunks(file_list, num_files)):
                 manifest_subset = { project: file_subset }
                 outfile = "{}_{:03d}.json.bz2".format(manifest_file.rstrip(".json.bz2"), i+1)
-                with open(outfile, "w") as f:
-                    f.write(bz2.compress(json.dumps(manifest_subset, indent=2, sort_keys=True)))
+                with open(outfile, "wb") as f:
+                    f.write(bz2.compress(json.dumps(manifest_subset, indent=2, sort_keys=True).encode()))
 
 
 def main():


### PR DESCRIPTION
Based on the solution by cgshuo in the issue #67.

Tested on Python 3.9.6 (MacOS) and 2.7.17 (Ubuntu 18.04).