### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -21,6 +21,3 @@ jobs:
                 repository: dnanexus/dxda
                 tag_with_ref: true
                 tag_with_sha: true
-                platforms:
-                  - linux/amd64
-                  - linux/arm64

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -8,13 +8,13 @@ on:
 jobs:
     build-and-push:
         name: Build and push Docker image
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
           
             - name: Build and push Docker images
-              uses: docker/build-push-action@v1
+              uses: docker/build-push-action@v2
               with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -21,3 +21,6 @@ jobs:
                 repository: dnanexus/dxda
                 tag_with_ref: true
                 tag_with_sha: true
+                platforms:
+                  - linux/amd64
+                  - linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV GOPATH="/go"
 ENV GO111MODULE=on
 
 # Install Go packages and Download agent executables
-RUN go install github.com/dnanexus/dxda/cmd/dx-download-agent@latest
+RUN go install github.com/dnanexus/dxda/cmd/dx-download-agent@master
 
 # Build architecture-specific binaries and packages
 RUN mkdir -p /builds/dx-download-agent-osx /builds/dx-download-agent-linux && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,27 @@
 # Development Dockerfile for dxda (Linux)
-FROM ubuntu:22.04
+FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS build
+
+ARG BUILDARCH TARGETOS TARGETARCH
 
 # Get dependencies for running Go
+ENV GOVERSION="1.16.6"
 RUN apt-get update && apt-get install -y wget git build-essential && \
-    wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
+    wget https://dl.google.com/go/go${GOVERSION}.linux-$BUILDARCH.tar.gz && \
+    tar -C /usr/local -xzf go${GOVERSION}.linux-${BUILDARCH}.tar.gz
 
 # Set environment variables for Go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 
-# Install Go packages and Download agent executables
-RUN go install github.com/dnanexus/dxda/cmd/dx-download-agent@master
+WORKDIR /src
+COPY . .
 
-# Build architecture-specific binaries and packages
-RUN mkdir -p /builds/dx-download-agent-osx /builds/dx-download-agent-linux && \
-    #CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o /builds/dx-download-agent-osx/dx-download-agent /go/src/github.com/dnanexus/dxda/cmd/dx-download-agent && \
-    cp /go/bin/dx-download-agent /builds/dx-download-agent-linux/ && \
-    cd /builds/ && \
-    chmod a+x dx-download-agent-linux/dx-download-agent && \
-    #chmod a+x dx-download-agent-osx/dx-download-agent && \
-    tar -cvf dx-download-agent-linux.tar dx-download-agent-linux && \
-    #tar -cvf dx-download-agent-osx.tar dx-download-agent-osx
-    cd ..
+RUN cd cmd/dx-download-agent && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/dx-download-agent .
 
 
+FROM ubuntu:22.04
+
+COPY --from=build /build/dx-download-agent /go/bin/
 
 ENTRYPOINT ["/go/bin/dx-download-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,4 @@ COPY . .
 RUN cd cmd/dx-download-agent && \
     go install .
 
-# Build architecture-specific binaries and packages
-RUN mkdir -p /builds/dx-download-agent-osx /builds/dx-download-agent-linux && \
-    #CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o /builds/dx-download-agent-osx/dx-download-agent /go/src/github.com/dnanexus/dxda/cmd/dx-download-agent && \
-    cp /go/bin/dx-download-agent /builds/dx-download-agent-linux/ && \
-    cd /builds/ && \
-    chmod a+x dx-download-agent-linux/dx-download-agent && \
-    #chmod a+x dx-download-agent-osx/dx-download-agent && \
-    tar -cvf dx-download-agent-linux.tar dx-download-agent-linux && \
-    #tar -cvf dx-download-agent-osx.tar dx-download-agent-osx
-    cd ..
-
 ENTRYPOINT ["/go/bin/dx-download-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y wget git build-essential && \
 # Set environment variables for Go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
-ENV GO111MODULE=on
 
 # Install Go packages and Download agent executables
 RUN go install github.com/dnanexus/dxda/cmd/dx-download-agent@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,33 @@
 # Development Dockerfile for dxda (Linux)
-FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS build
+FROM ubuntu:22.04
 
-ARG BUILDARCH TARGETOS TARGETARCH
+ARG TARGETARCH
 
 # Get dependencies for running Go
 ENV GOVERSION="1.16.6"
 RUN apt-get update && apt-get install -y wget git build-essential && \
-    wget https://dl.google.com/go/go${GOVERSION}.linux-$BUILDARCH.tar.gz && \
-    tar -C /usr/local -xzf go${GOVERSION}.linux-${BUILDARCH}.tar.gz
+    wget https://dl.google.com/go/go${GOVERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GOVERSION}.linux-${TARGETARCH}.tar.gz
 
 # Set environment variables for Go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
 
-WORKDIR /src
+WORKDIR /dxda
 COPY . .
 
 RUN cd cmd/dx-download-agent && \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/dx-download-agent .
+    go install .
 
-
-FROM ubuntu:22.04
-
-COPY --from=build /build/dx-download-agent /go/bin/
+# Build architecture-specific binaries and packages
+RUN mkdir -p /builds/dx-download-agent-osx /builds/dx-download-agent-linux && \
+    #CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o /builds/dx-download-agent-osx/dx-download-agent /go/src/github.com/dnanexus/dxda/cmd/dx-download-agent && \
+    cp /go/bin/dx-download-agent /builds/dx-download-agent-linux/ && \
+    cd /builds/ && \
+    chmod a+x dx-download-agent-linux/dx-download-agent && \
+    #chmod a+x dx-download-agent-osx/dx-download-agent && \
+    tar -cvf dx-download-agent-linux.tar dx-download-agent-linux && \
+    #tar -cvf dx-download-agent-osx.tar dx-download-agent-osx
+    cd ..
 
 ENTRYPOINT ["/go/bin/dx-download-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 # Development Dockerfile for dxda (Linux)
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 # Get dependencies for running Go
 RUN apt-get update && apt-get install -y wget git build-essential && \
-    wget https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.13.6.linux-amd64.tar.gz
+    wget https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 
 # Set environment variables for Go
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH="/go"
+ENV GO111MODULE=on
 
 # Install Go packages and Download agent executables
-RUN go get github.com/google/subcommands && go install github.com/google/subcommands && \
-    go get github.com/dnanexus/dxda && go install github.com/dnanexus/dxda && \
-    go install github.com/dnanexus/dxda/cmd/dx-download-agent
+RUN go install github.com/dnanexus/dxda/cmd/dx-download-agent@latest
 
 # Build architecture-specific binaries and packages
 RUN mkdir -p /builds/dx-download-agent-osx /builds/dx-download-agent-linux && \


### PR DESCRIPTION
- update base image to Ubuntu 22.04
- update Go version to 1.16.6 (as per releases)
- fix build error by using `install` instead of `get` (closes #70)