### PR TITLE
PTFM-35633 Lower default max of goroutines

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   macos:
     name: Macos build
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       GOOS: darwin
       GOARCH: amd64

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   macos:
     name: Macos build
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       GOOS: darwin
       GOARCH: amd64

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ This command will perform an inspection of the files and ensure that their MD5su
 
 ## Execution options
 
-* `-max_threads` (integer): maximum # of concurrent threads to use when downloading files
+* `-num_threads` (integer): maximum # of concurrent threads to use when downloading or inspecting files
 
 For example, the commmand
 
 ```
-dx-download-agent download -max_threads=20 exome_bams_manifest.json.bz2
+dx-download-agent download -num_threads=20 exome_bams_manifest.json.bz2
 ```
 
 will create a worker pool of 20 threads that will download parts of files in parallel.  A maximum of 20 workers will perform downloads at any time.  Rate-limiting of downloads can be controlled to an extent by varying this number.

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -141,7 +141,7 @@ type inspectCmd struct {
 	verbose    bool
 }
 
-const inspectUsage = "dx-download-agent inspect [-max_threads=N] <manifest.json.bz2>"
+const inspectUsage = "dx-download-agent inspect [-num_threads=N] <manifest.json.bz2>"
 
 func (*inspectCmd) Name() string { return "inspect" }
 func (*inspectCmd) Synopsis() string {

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -21,7 +21,7 @@ type downloadCmd struct {
 
 var err error
 
-const downloadUsage = "dx-download-agent download [-max_threads=N] <manifest.json.bz2>"
+const downloadUsage = "dx-download-agent download [-num_threads=N] <manifest.json.bz2>"
 
 func (*downloadCmd) Name() string     { return "download" }
 func (*downloadCmd) Synopsis() string { return "Download files in a manifest" }
@@ -137,7 +137,8 @@ func (p *progressCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 
 // inspect the files, and see that there are no checksum errors
 type inspectCmd struct {
-	verbose bool
+	numThreads int
+	verbose    bool
 }
 
 const inspectUsage = "dx-download-agent inspect [-max_threads=N] <manifest.json.bz2>"
@@ -150,6 +151,7 @@ func (*inspectCmd) Usage() string {
 	return downloadUsage
 }
 func (p *inspectCmd) SetFlags(f *flag.FlagSet) {
+	f.IntVar(&p.numThreads, "num_threads", 0, "Number of threads to use when downloading files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.")
 	f.BoolVar(&p.verbose, "verbose", false, "verbose logging")
 }
 
@@ -169,6 +171,7 @@ func (p *inspectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 
 	var opts dxda.Opts
 	opts.Verbose = p.verbose
+	opts.NumThreads = p.numThreads
 
 	st := dxda.NewDxDa(dxEnv, fname, opts)
 	defer st.Close()

--- a/dxda.go
+++ b/dxda.go
@@ -150,7 +150,7 @@ func calcNumThreads(maxChunkSize int64) int {
 	fmt.Printf("number of machine cores: %d\n", numCPUs)
 	fmt.Printf("memory size: %d GiB\n", hwMemoryBytes/GiB)
 
-	numThreads := MinInt(2*numCPUs, maxNumThreads)
+	numThreads := MinInt(numCPUs, maxNumThreads)
 	memoryCostPerThread := 3 * int64(maxChunkSize)
 
 	for numThreads > minNumThreads {

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ const (
 
 	// Extracted automatically with a shell script, so keep the format:
 	// version = XXXX
-	Version = "v0.5.12"
+	Version = "v0.6.0"
 )
 
 // Configuration options for the download agent


### PR DESCRIPTION
Reduce the default number of goroutines for both `download` and `inspect` to the number of CPUs, not `2*CPUs`. 

Fix the `-num_threads` argument for `dxda inspect` as shown in the help output. 