### PR TITLE
TIP-3680 Fix dxda for writable symlinks

### DIFF
--- a/dx_describe.go
+++ b/dx_describe.go
@@ -150,7 +150,7 @@ func submit(
 		// If this is a symlink, create structure with
 		// all the relevant information.
 		var symlink *DXSymlink = nil
-		if descRaw.Drive != nil {
+		if descRaw.Parts == nil && descRaw.Drive != nil {
 			symlink = &DXSymlink{
 				MD5:   *descRaw.MD5,
 				Drive: *descRaw.Drive,


### PR DESCRIPTION
TIP-3680 Fix dxda for writable symlinks

With writable symlinks we will populate parts on file object, so they can be treated like regular files when downloading inside dxda. But there might be some old read symlinks that don't get fully migrated over, so we want to keep existing symlink logic there for those cases.