### PR TITLE
PTFM-39211 implement additional checksum types for integrity checks

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,7 @@ jobs:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
           with:
-            go-version: '1.20.11'
+            go-version: '1.22.12'
         - name: Build Macos executable
           run: |
             set -x
@@ -52,7 +52,7 @@ jobs:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
           with:
-            go-version: '1.20.11'
+            go-version: '1.22.12'
         - name: go dependencies
           run: go get -u github.com/google/subcommands
         - name: Build Windows executable

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -17,7 +17,7 @@ jobs:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
           with:
-            go-version: '1.20.11'
+            go-version: '1.22.12'
         - name: Build Macos executable
           run: |
             set -x
@@ -35,7 +35,7 @@ jobs:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 # v2.1.5
           with:
-            go-version: '1.20.11'
+            go-version: '1.22.12'
         - name: Build Windows executable
           run: |
             go build -o dx-download-agent.exe cmd/dx-download-agent/dx-download-agent.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM ubuntu:22.04
 ARG TARGETARCH
 
 # Get dependencies for running Go
-ENV GOVERSION="1.20.11"
+ENV GOVERSION="1.22.12"
 RUN apt-get update && apt-get install -y wget git build-essential && \
     wget https://dl.google.com/go/go${GOVERSION}.linux-${TARGETARCH}.tar.gz && \
-    tar -C /usr/local -xzf go${GOVERSION}.linux-${TARGETARCH}.tar.gz && \ 
+    tar -C /usr/local -xzf go${GOVERSION}.linux-${TARGETARCH}.tar.gz && \
     rm go${GOVERSION}.linux-${TARGETARCH}.tar.gz
 
 # Set environment variables for Go

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ To get started with `dx-download-agent`, download the the latest pre-compiled bi
         "2": { "size": 5,  "md5": "39239329" }
       }
     },
+    {
+      "id": "file-YYYY",
+      "name": "foo",
+      "folder": "/path/to",
+      "checksumType": "CRC64NVME"
+      "parts": {
+        "1": { "size": 10, "checksum": "12xUBUlUwUM=" },
+      }
+    },
     "..."
   ],
   "project-BBBB": [ "..." ]
@@ -104,6 +113,8 @@ Fields (all fields are strings unless otherwise specified)
 * `size` (integer): size of the part
 * `block_size` (integer): primary block size of file (assumed equal to `size` except for the last part)
 * `bytes_fetched` (integer <= `size`): total number of bytes downloaded
+* `checksum_type` (optional): type of checksum used (e.g. `CRC64NVME`, `CRC32C`, `CRC32`, `SHA256`, `SHA1`)
+* `checksum` (optional): checksum value for the part ID if not using md5
 
 It is up to the implementation to decide whether or not `bytes_fetched` is updated in a more coarse- vs. fine-grained fashion.  For example, `bytes_fetched` can be updated only when the part download is complete. In this case, its values will only be `0` or the value of `size`.
 

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=amd64 ubuntu:20.04
 
-ENV GO_VERSION=1.20.11
+ENV GO_VERSION=1.22.12
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,80 @@
+package dxda
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/minio/crc64nvme"
+)
+
+const (
+	ChecksumCRC64NVME = "CRC64NVME"
+	ChecksumCRC32C    = "CRC32C"
+	ChecksumCRC32     = "CRC32"
+	ChecksumSHA256    = "SHA256"
+	ChecksumSHA1      = "SHA1"
+)
+
+func CalculateChecksum(checksumType string, data []byte) (string, error) {
+	switch checksumType {
+	case ChecksumCRC64NVME:
+		return calculateCRC64NVME(data), nil
+	case ChecksumCRC32C:
+		return calculateCRC32C(data), nil
+	case ChecksumCRC32:
+		return calculateCRC32(data), nil
+	case ChecksumSHA256:
+		return calculateSHA256(data), nil
+	case ChecksumSHA1:
+		return calculateSHA1(data), nil
+	default:
+		return "", fmt.Errorf("unsupported checksum type: %s", checksumType)
+	}
+}
+
+func calculateCRC64NVME(data []byte) string {
+	return uint64ToBase64String(crc64nvme.Checksum(data))
+}
+
+func calculateCRC32C(data []byte) string {
+	// Castagnoli polynomial is used in CRC32C standard
+	table := crc32.MakeTable(crc32.Castagnoli)
+	return uint32ToBase64String(crc32.Checksum(data, table))
+}
+
+func calculateCRC32(data []byte) string {
+	// IEEE polynomial is used in CRC32 standard
+	table := crc32.MakeTable(crc32.IEEE)
+	return uint32ToBase64String(crc32.Checksum(data, table))
+}
+
+func calculateSHA256(data []byte) string {
+	hasher := sha256.New()
+	hasher.Write(data)
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func calculateSHA1(data []byte) string {
+	hasher := sha1.New()
+	hasher.Write(data)
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func uint64ToBase64String(num uint64) string {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, num)
+
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func uint32ToBase64String(num uint32) string {
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, num)
+
+	return base64.StdEncoding.EncodeToString(buf)
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,77 @@
+package dxda
+
+import "testing"
+
+func TestCRC64NVME(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+	expectedChecksum := "12xUBUlUwUM="
+
+	checksum, err := CalculateChecksum("CRC64NVME", data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if checksum != expectedChecksum {
+		t.Errorf("Expected checksum %s, got %s", expectedChecksum, checksum)
+	}
+}
+
+func TestCRC32C(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+	expectedChecksum := "ImIEBA=="
+
+	checksum, err := CalculateChecksum("CRC32C", data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if checksum != expectedChecksum {
+		t.Errorf("Expected checksum %s, got %s", expectedChecksum, checksum)
+	}
+}
+
+func TestCRC32(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+	expectedChecksum := "QU+jOQ=="
+
+	checksum, err := CalculateChecksum("CRC32", data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if checksum != expectedChecksum {
+		t.Errorf("Expected checksum %s, got %s", expectedChecksum, checksum)
+	}
+}
+
+func TestSHA256(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+	expectedChecksum := "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+
+	checksum, err := CalculateChecksum("SHA256", data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if checksum != expectedChecksum {
+		t.Errorf("Expected checksum %s, got %s", expectedChecksum, checksum)
+	}
+}
+
+func TestSHA1(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+	expectedChecksum := "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+
+	checksum, err := CalculateChecksum("SHA1", data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if checksum != expectedChecksum {
+		t.Errorf("Expected checksum %s, got %s", expectedChecksum, checksum)
+	}
+}
+
+func TestUnsupportedChecksum(t *testing.T) {
+	data := []byte("The quick brown fox jumps over the lazy dog")
+
+	_, err := CalculateChecksum("MD5", data)
+	if err == nil {
+		t.Fatalf("Expected error for unsupported checksum type, got nil")
+	}
+}

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -84,6 +84,11 @@ func (p *downloadCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 		fmt.Printf("Creating manifest database %s\n", fname+".stats.db")
 		st.CreateManifestDB(*manifest, fname)
 	} else {
+		// Check database schema is compatible with current version
+		if err := st.CheckSchemaVersion(); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
 		fmt.Printf("Ensuring files are created for existing manifest \n")
 		st.PrepareFilesForDownload(*manifest)
 	}
@@ -175,6 +180,12 @@ func (p *inspectCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 
 	st := dxda.NewDxDa(dxEnv, fname, opts)
 	defer st.Close()
+
+	// Check database schema is compatible with current version
+	if err := st.CheckSchemaVersion(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	integrityFlag := st.CheckFileIntegrity()
 	if !integrityFlag {

--- a/dx_describe.go
+++ b/dx_describe.go
@@ -24,6 +24,7 @@ type DxDescribeDataObject struct {
 	Size          int64
 	Parts         map[string]DXPart // a list of parts for a DNAx file
 	Symlink       *DXSymlink
+	ChecksumType  string
 }
 
 // description of part of a file
@@ -32,8 +33,9 @@ type DXPart struct {
 	Id int
 
 	// these fields are in the input JSON
-	MD5  string `json:"md5"`
-	Size int    `json:"size"`
+	MD5      string  `json:"md5"`
+	Size     int     `json:"size"`
+	Checksum *string `json:"checksum,omitempty"`
 }
 
 // a full URL for symbolic links, with a corresponding MD5 checksum for
@@ -78,6 +80,7 @@ type DxDescribeRaw struct {
 	Symlink       *DxSymlinkRaw     `json:"symlinkPath,omitempty"`
 	MD5           *string           `json:"md5,omitempty"`
 	Drive         *string           `json:"drive,omitempty"`
+	ChecksumType  *string           `json:"checksumType,omitempty"`
 }
 
 // Describe a large number of file-ids in one API call.
@@ -103,6 +106,7 @@ func submit(
 			"symlinkPath":   true,
 			"drive":         true,
 			"md5":           true,
+			"checksumType":  true,
 		},
 	}
 	var payload []byte
@@ -165,6 +169,7 @@ func submit(
 			ArchivalState: descRaw.ArchivalState,
 			Size:          descRaw.Size,
 			Parts:         descRaw.Parts,
+			ChecksumType:  *descRaw.ChecksumType,
 			Symlink:       symlink,
 		}
 		//fmt.Printf("%v\n", desc)

--- a/dxda.go
+++ b/dxda.go
@@ -641,8 +641,6 @@ func (st *State) downloadRegPartCheckSum(
 
 	// compute the checksum as we go
 	hasher := md5.New()
-	var chunkData []byte
-	var partData []byte
 
 	// loop through the part, reading in chunk pieces
 	endPart := p.Offset + int64(p.Size) - 1
@@ -666,8 +664,6 @@ func (st *State) downloadRegPartCheckSum(
 
 		// update the checksum
 		_, err = io.Copy(hasher, bytes.NewReader(body))
-		chunkData = body
-		partData = append(partData, chunkData...)
 
 		check(err)
 	}
@@ -676,19 +672,6 @@ func (st *State) downloadRegPartCheckSum(
 	if p.MD5 != "" {
 		diskSum := hex.EncodeToString(hasher.Sum(nil))
 		if diskSum != p.MD5 {
-			return false, nil
-		}
-	}
-
-	// verify other checksums
-	if p.ChecksumType != "" {
-		var calculatedChecksum string
-		if p.ChecksumType != ChecksumCRC64NVME {
-			calculatedChecksum, err = CalculateChecksum(p.ChecksumType, chunkData)
-		} else {
-			calculatedChecksum, err = CalculateChecksum(p.ChecksumType, partData)
-		}
-		if calculatedChecksum != p.Checksum || err != nil {
 			return false, nil
 		}
 	}

--- a/dxda.go
+++ b/dxda.go
@@ -296,7 +296,7 @@ func (st *State) addRegularFileToTable(txn *sql.Tx, f DXFileRegular) {
 				INSERT INTO manifest_regular_stats
 				VALUES ('%s', '%s', '%s', '%s', %d, '%d', '%d', '%s', '%d', '%d', '%s', '%s');
 				`,
-			f.Id, f.ProjId, f.Name, f.Folder, p.Id, offset, p.Size, p.MD5, 0, 0, *f.ChecksumType, *p.Checksum)
+			f.Id, f.ProjId, f.Name, f.Folder, p.Id, offset, p.Size, p.MD5, 0, 0, safeDeref(f.ChecksumType, ""), safeDeref(p.Checksum, ""))
 		_, err := txn.Exec(sqlStmt)
 		check(err)
 		offset += int64(p.Size)

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,11 @@ go 1.20
 require (
 	github.com/google/subcommands v1.2.0
 	github.com/mattn/go-sqlite3 v1.14.18
+	github.com/minio/crc64nvme v1.1.1
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+)
+
+require (
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dnanexus/dxda
 
-go 1.20
+go 1.22
 
 require (
 	github.com/google/subcommands v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
 github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
+github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/mattn/go-sqlite3 v1.14.18 h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI=
 github.com/mattn/go-sqlite3 v1.14.18/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/minio/crc64nvme v1.1.1 h1:8dwx/Pz49suywbO+auHCBpCtlW1OfpcLN7wYgVR6wAI=
+github.com/minio/crc64nvme v1.1.1/go.mod h1:eVfm2fAzLlxMdUGc0EEBGSMmPwmXD5XiNRpnu9J3bvg=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/scripts/create_manifest.py
+++ b/scripts/create_manifest.py
@@ -33,7 +33,8 @@ def fileID2manifest(fdetails, project):
     pruned['id'] = fdetails['id']
     pruned['name'] = fdetails['name']
     pruned['folder'] = fdetails['folder']
-    pruned['checksumType'] = fdetails['checksumType']
+    if fdetails['checksumType']:
+        pruned['checksumType'] = fdetails['checksumType']
      # Symlinks do not contain parts
     if fdetails['parts']:
         pruned['parts'] = {pid: {k:v for k,v in pdetails.items() if k == "md5" or k == "size" or k == "checksum"} for pid, pdetails in fdetails['parts'].items()}

--- a/scripts/create_manifest.py
+++ b/scripts/create_manifest.py
@@ -33,9 +33,10 @@ def fileID2manifest(fdetails, project):
     pruned['id'] = fdetails['id']
     pruned['name'] = fdetails['name']
     pruned['folder'] = fdetails['folder']
+    pruned['checksumType'] = fdetails['checksumType']
      # Symlinks do not contain parts
     if fdetails['parts']:
-        pruned['parts'] = {pid: {k:v for k,v in pdetails.items() if k == "md5" or k == "size"} for pid, pdetails in fdetails['parts'].items()}
+        pruned['parts'] = {pid: {k:v for k,v in pdetails.items() if k == "md5" or k == "size" or k == "checksum"} for pid, pdetails in fdetails['parts'].items()}
     return pruned
 
 def main():
@@ -48,7 +49,7 @@ def main():
 
     project, folder, _ = resolve_existing_path(args.folder)
 
-    ids = dxpy.find_data_objects(classname='file', first_page_size=1000, state='closed', describe={'fields': {'id': True, 'name': True, 'folder': True, 'parts': True, 'state': True, 'archivalState': True }}, project=project, folder=folder, recurse=args.recursive)
+    ids = dxpy.find_data_objects(classname='file', first_page_size=1000, state='closed', describe={'fields': {'id': True, 'name': True, 'folder': True, 'parts': True, 'state': True, 'archivalState': True, 'checksumType': True }}, project=project, folder=folder, recurse=args.recursive)
     manifest = { project: [] }
 
     for i,f in enumerate(ids):

--- a/util.go
+++ b/util.go
@@ -182,3 +182,10 @@ func PrintLogAndOut(a string, args ...interface{}) {
 func memorySizeBytes() int64 {
 	return int64(memory.TotalMemory())
 }
+
+func safeDeref(p *string, fallback string) string {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}


### PR DESCRIPTION
This PR adds support for other checksum algorithms used with Symlinks 2.0.

Changes: 
- **upgrade to Go 1.22** so we can use crc64nvme package
- add additional attributes `checksum_type` and `checksum` to the stats db
- fetch checksum attributes to manifest file using `scripts/create_manifest.py`
- add support for new checksums to the inspect command
- add support for new checksums to the download command
- ignore MD5 if not provided
- ignore other checksums if not provided