### PR TITLE
DOCS-2791 Fix dxda help strings

### DIFF
--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"strings"
 
 	// The dxda package should contain all core functionality
 	"github.com/dnanexus/dxda"
@@ -21,7 +23,13 @@ type downloadCmd struct {
 
 var err error
 
+const rootDescription = "CLI tool to manage the download of files from DNAnexus"
 const downloadUsage = "dx-download-agent download [-num_threads=N] <manifest.json.bz2>"
+const commandsUsage = "dx-download-agent commands"
+const flagsUsage = "dx-download-agent flags [<subcommand>]"
+const helpUsage = "dx-download-agent help [<subcommand>]"
+const inspectSynopsis = "Inspect files downloaded in a manifest and validate their integrity"
+const versionUsage = "dx-download-agent version"
 
 func (*downloadCmd) Name() string     { return "download" }
 func (*downloadCmd) Synopsis() string { return "Download files in a manifest" }
@@ -108,7 +116,7 @@ type progressCmd struct {
 }
 
 func (*progressCmd) Name() string     { return "progress" }
-func (*progressCmd) Synopsis() string { return "show current download progress" }
+func (*progressCmd) Synopsis() string { return "Show current download progress" }
 
 const progressUsage = "dx-download-agent progress <manifest.json.bz2>"
 
@@ -150,13 +158,13 @@ const inspectUsage = "dx-download-agent inspect [-num_threads=N] <manifest.json.
 
 func (*inspectCmd) Name() string { return "inspect" }
 func (*inspectCmd) Synopsis() string {
-	return "Inspect files downloaded in a manifest + additional 'health' checks"
+	return inspectSynopsis
 }
 func (*inspectCmd) Usage() string {
-	return downloadUsage
+	return inspectUsage
 }
 func (p *inspectCmd) SetFlags(f *flag.FlagSet) {
-	f.IntVar(&p.numThreads, "num_threads", 0, "Number of threads to use when downloading files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.")
+	f.IntVar(&p.numThreads, "num_threads", 0, "Number of threads to use when validating files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.")
 	f.BoolVar(&p.verbose, "verbose", false, "verbose logging")
 }
 
@@ -199,19 +207,183 @@ type versionCmd struct {
 }
 
 func (*versionCmd) Name() string               { return "version" }
-func (*versionCmd) Synopsis() string           { return "get the version" }
-func (*versionCmd) Usage() string              { return "get the dx-download-agent version" }
+func (*versionCmd) Synopsis() string           { return "Get the version" }
+func (*versionCmd) Usage() string              { return versionUsage }
 func (p *versionCmd) SetFlags(f *flag.FlagSet) {}
 func (p *versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	fmt.Println(dxda.Version)
 	return subcommands.ExitSuccess
 }
 
+type commandsCmd struct{}
+
+func (*commandsCmd) Name() string           { return "commands" }
+func (*commandsCmd) Synopsis() string       { return "List all command names" }
+func (*commandsCmd) Usage() string          { return commandsUsage }
+func (*commandsCmd) SetFlags(*flag.FlagSet) {}
+func (*commandsCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if f.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, commandsUsage)
+		return subcommands.ExitUsageError
+	}
+	visitRegisteredCommands(func(cmd subcommands.Command) {
+		fmt.Fprintln(os.Stdout, cmd.Name())
+	})
+	return subcommands.ExitSuccess
+}
+
+type flagsCmd struct{}
+
+func (*flagsCmd) Name() string           { return "flags" }
+func (*flagsCmd) Synopsis() string       { return "Describe all known top-level flags" }
+func (*flagsCmd) Usage() string          { return flagsUsage }
+func (*flagsCmd) SetFlags(*flag.FlagSet) {}
+func (*flagsCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if f.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, flagsUsage)
+		return subcommands.ExitUsageError
+	}
+
+	if f.NArg() == 0 {
+		printFlags(os.Stdout, flag.CommandLine)
+		return subcommands.ExitSuccess
+	}
+
+	cmd := findRegisteredCommand(f.Arg(0))
+	if cmd == nil {
+		fmt.Fprintf(os.Stderr, "Subcommand %s not understood\n", f.Arg(0))
+		return subcommands.ExitFailure
+	}
+
+	subflags := flag.NewFlagSet(cmd.Name(), flag.PanicOnError)
+	cmd.SetFlags(subflags)
+	printFlags(os.Stdout, subflags)
+	return subcommands.ExitSuccess
+}
+
+type helpCmd struct{}
+
+func (*helpCmd) Name() string           { return "help" }
+func (*helpCmd) Synopsis() string       { return "Describe subcommands and their syntax" }
+func (*helpCmd) Usage() string          { return helpUsage }
+func (*helpCmd) SetFlags(*flag.FlagSet) {}
+func (*helpCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	switch f.NArg() {
+	case 0:
+		explainTopLevel(os.Stdout)
+		return subcommands.ExitSuccess
+	case 1:
+		cmd := findRegisteredCommand(f.Arg(0))
+		if cmd != nil {
+			explainCommand(os.Stdout, cmd)
+			return subcommands.ExitSuccess
+		}
+		fmt.Fprintf(os.Stderr, "Subcommand %s not understood\n", f.Arg(0))
+	default:
+	}
+
+	fmt.Fprintln(os.Stderr, helpUsage)
+	return subcommands.ExitUsageError
+}
+
+func printCommandSummary(w io.Writer, cmd subcommands.Command) {
+	fmt.Fprintf(w, "  %-15s %s\n", cmd.Name(), cmd.Synopsis())
+}
+
+func visitRegisteredCommands(fn func(subcommands.Command)) {
+	subcommands.DefaultCommander.VisitCommands(func(_ *subcommands.CommandGroup, cmd subcommands.Command) {
+		fn(cmd)
+	})
+}
+
+func findRegisteredCommand(name string) subcommands.Command {
+	var found subcommands.Command
+	visitRegisteredCommands(func(cmd subcommands.Command) {
+		if found == nil && cmd.Name() == name {
+			found = cmd
+		}
+	})
+	return found
+}
+
+func printFlags(w io.Writer, fs *flag.FlagSet) {
+	fs.VisitAll(func(f *flag.Flag) {
+		name, usage := flag.UnquoteUsage(f)
+		line := fmt.Sprintf("  -%s", f.Name)
+		if name != "" {
+			line += " " + name
+		}
+		fmt.Fprintln(w, line)
+
+		trimmedUsage := strings.TrimSpace(usage)
+		if trimmedUsage == "" {
+			return
+		}
+
+		for _, usageLine := range strings.Split(trimmedUsage, "\n") {
+			fmt.Fprintf(w, "      %s\n", strings.TrimSpace(usageLine))
+		}
+	})
+}
+
+func explainTopLevel(w io.Writer) {
+	fmt.Fprintf(w, "dx-download-agent %s\n", dxda.Version)
+	fmt.Fprintf(w, "%s\n\n", rootDescription)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintf(w, "  %s\n", downloadUsage)
+	fmt.Fprintf(w, "  %s\n", inspectUsage)
+	fmt.Fprintf(w, "  %s\n", progressUsage)
+	fmt.Fprintf(w, "  %s\n\n", versionUsage)
+	fmt.Fprintln(w, "Authentication:")
+	fmt.Fprintln(w, "  Set DX_API_TOKEN or configure ~/.dnanexus_config/environment.json.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Primary commands:")
+	printCommandSummary(w, &downloadCmd{})
+	printCommandSummary(w, &inspectCmd{})
+	printCommandSummary(w, &progressCmd{})
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Reference commands:")
+	printCommandSummary(w, &versionCmd{})
+	printCommandSummary(w, &helpCmd{})
+	printCommandSummary(w, &flagsCmd{})
+	printCommandSummary(w, &commandsCmd{})
+	fmt.Fprintln(w)
+}
+
+func explainCommand(w io.Writer, cmd subcommands.Command) {
+	usage := strings.TrimSpace(cmd.Usage())
+	if usage != "" {
+		fmt.Fprintln(w, usage)
+	}
+
+	synopsis := strings.TrimSpace(cmd.Synopsis())
+	if synopsis != "" {
+		fmt.Fprintf(w, "\n%s\n", synopsis)
+	}
+
+	subflags := flag.NewFlagSet(cmd.Name(), flag.PanicOnError)
+	cmd.SetFlags(subflags)
+
+	var hasFlags bool
+	subflags.VisitAll(func(*flag.Flag) {
+		hasFlags = true
+	})
+	if !hasFlags {
+		return
+	}
+
+	fmt.Fprintln(w)
+	printFlags(w, subflags)
+}
+
 // The CLI is simply a wrapper around the dxda package
 func main() {
-	subcommands.Register(subcommands.HelpCommand(), "")
-	subcommands.Register(subcommands.FlagsCommand(), "")
-	subcommands.Register(subcommands.CommandsCommand(), "")
+	subcommands.DefaultCommander.Explain = explainTopLevel
+	subcommands.DefaultCommander.ExplainCommand = explainCommand
+
+	subcommands.Register(&helpCmd{}, "")
+	subcommands.Register(&flagsCmd{}, "")
+	subcommands.Register(&commandsCmd{}, "")
 	subcommands.Register(&downloadCmd{}, "")
 	subcommands.Register(&progressCmd{}, "")
 	subcommands.Register(&inspectCmd{}, "")
@@ -219,7 +391,7 @@ func main() {
 
 	// TODO: modify this to use individual subcommand help
 	if len(os.Args) == 1 {
-		fmt.Printf("Usage:\n  For progress:\n  $ %s\n\n  For downloading:\n  $ %s\n", progressUsage, downloadUsage)
+		explainTopLevel(os.Stderr)
 		os.Exit(1)
 	}
 

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -25,9 +25,7 @@ var err error
 
 const rootDescription = "CLI tool to manage the download of files from DNAnexus"
 const downloadUsage = "dx-download-agent download [-num_threads=N] <manifest.json.bz2>"
-const commandsUsage = "dx-download-agent commands"
 const flagsUsage = "dx-download-agent flags [<subcommand>]"
-const helpUsage = "dx-download-agent help [<subcommand>]"
 const inspectSynopsis = "Inspect files downloaded in a manifest and validate their integrity"
 const versionUsage = "dx-download-agent version"
 
@@ -215,23 +213,6 @@ func (p *versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	return subcommands.ExitSuccess
 }
 
-type commandsCmd struct{}
-
-func (*commandsCmd) Name() string           { return "commands" }
-func (*commandsCmd) Synopsis() string       { return "List all command names" }
-func (*commandsCmd) Usage() string          { return commandsUsage }
-func (*commandsCmd) SetFlags(*flag.FlagSet) {}
-func (*commandsCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	if f.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, commandsUsage)
-		return subcommands.ExitUsageError
-	}
-	visitRegisteredCommands(func(cmd subcommands.Command) {
-		fmt.Fprintln(os.Stdout, cmd.Name())
-	})
-	return subcommands.ExitSuccess
-}
-
 type flagsCmd struct{}
 
 func (*flagsCmd) Name() string           { return "flags" }
@@ -259,31 +240,6 @@ func (*flagsCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	cmd.SetFlags(subflags)
 	printFlags(os.Stdout, subflags)
 	return subcommands.ExitSuccess
-}
-
-type helpCmd struct{}
-
-func (*helpCmd) Name() string           { return "help" }
-func (*helpCmd) Synopsis() string       { return "Describe subcommands and their syntax" }
-func (*helpCmd) Usage() string          { return helpUsage }
-func (*helpCmd) SetFlags(*flag.FlagSet) {}
-func (*helpCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	switch f.NArg() {
-	case 0:
-		explainTopLevel(os.Stdout)
-		return subcommands.ExitSuccess
-	case 1:
-		cmd := findRegisteredCommand(f.Arg(0))
-		if cmd != nil {
-			explainCommand(os.Stdout, cmd)
-			return subcommands.ExitSuccess
-		}
-		fmt.Fprintf(os.Stderr, "Subcommand %s not understood\n", f.Arg(0))
-	default:
-	}
-
-	fmt.Fprintln(os.Stderr, helpUsage)
-	return subcommands.ExitUsageError
 }
 
 func printCommandSummary(w io.Writer, cmd subcommands.Command) {
@@ -344,9 +300,9 @@ func explainTopLevel(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Reference commands:")
 	printCommandSummary(w, &versionCmd{})
-	printCommandSummary(w, &helpCmd{})
+	printCommandSummary(w, subcommands.HelpCommand())
 	printCommandSummary(w, &flagsCmd{})
-	printCommandSummary(w, &commandsCmd{})
+	printCommandSummary(w, subcommands.CommandsCommand())
 	fmt.Fprintln(w)
 }
 
@@ -381,9 +337,9 @@ func main() {
 	subcommands.DefaultCommander.Explain = explainTopLevel
 	subcommands.DefaultCommander.ExplainCommand = explainCommand
 
-	subcommands.Register(&helpCmd{}, "")
+	subcommands.Register(subcommands.HelpCommand(), "")
 	subcommands.Register(&flagsCmd{}, "")
-	subcommands.Register(&commandsCmd{}, "")
+	subcommands.Register(subcommands.CommandsCommand(), "")
 	subcommands.Register(&downloadCmd{}, "")
 	subcommands.Register(&progressCmd{}, "")
 	subcommands.Register(&inspectCmd{}, "")

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -23,7 +23,7 @@ type downloadCmd struct {
 
 var err error
 
-const rootDescription = "CLI tool to manage the download of files from DNAnexus"
+const rootDescription = "CLI tool to manage the download of files from the DNAnexus Platform"
 const downloadUsage = "dx-download-agent download [-num_threads=N] <manifest.json.bz2>"
 const inspectSynopsis = "Inspect files downloaded in a manifest and validate their integrity"
 const versionUsage = "dx-download-agent version"

--- a/cmd/dx-download-agent/dx-download-agent.go
+++ b/cmd/dx-download-agent/dx-download-agent.go
@@ -25,7 +25,6 @@ var err error
 
 const rootDescription = "CLI tool to manage the download of files from DNAnexus"
 const downloadUsage = "dx-download-agent download [-num_threads=N] <manifest.json.bz2>"
-const flagsUsage = "dx-download-agent flags [<subcommand>]"
 const inspectSynopsis = "Inspect files downloaded in a manifest and validate their integrity"
 const versionUsage = "dx-download-agent version"
 
@@ -213,53 +212,8 @@ func (p *versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	return subcommands.ExitSuccess
 }
 
-type flagsCmd struct{}
-
-func (*flagsCmd) Name() string           { return "flags" }
-func (*flagsCmd) Synopsis() string       { return "Describe all known top-level flags" }
-func (*flagsCmd) Usage() string          { return flagsUsage }
-func (*flagsCmd) SetFlags(*flag.FlagSet) {}
-func (*flagsCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	if f.NArg() > 1 {
-		fmt.Fprintln(os.Stderr, flagsUsage)
-		return subcommands.ExitUsageError
-	}
-
-	if f.NArg() == 0 {
-		printFlags(os.Stdout, flag.CommandLine)
-		return subcommands.ExitSuccess
-	}
-
-	cmd := findRegisteredCommand(f.Arg(0))
-	if cmd == nil {
-		fmt.Fprintf(os.Stderr, "Subcommand %s not understood\n", f.Arg(0))
-		return subcommands.ExitFailure
-	}
-
-	subflags := flag.NewFlagSet(cmd.Name(), flag.PanicOnError)
-	cmd.SetFlags(subflags)
-	printFlags(os.Stdout, subflags)
-	return subcommands.ExitSuccess
-}
-
 func printCommandSummary(w io.Writer, cmd subcommands.Command) {
 	fmt.Fprintf(w, "  %-15s %s\n", cmd.Name(), cmd.Synopsis())
-}
-
-func visitRegisteredCommands(fn func(subcommands.Command)) {
-	subcommands.DefaultCommander.VisitCommands(func(_ *subcommands.CommandGroup, cmd subcommands.Command) {
-		fn(cmd)
-	})
-}
-
-func findRegisteredCommand(name string) subcommands.Command {
-	var found subcommands.Command
-	visitRegisteredCommands(func(cmd subcommands.Command) {
-		if found == nil && cmd.Name() == name {
-			found = cmd
-		}
-	})
-	return found
 }
 
 func printFlags(w io.Writer, fs *flag.FlagSet) {
@@ -301,7 +255,7 @@ func explainTopLevel(w io.Writer) {
 	fmt.Fprintln(w, "Reference commands:")
 	printCommandSummary(w, &versionCmd{})
 	printCommandSummary(w, subcommands.HelpCommand())
-	printCommandSummary(w, &flagsCmd{})
+	printCommandSummary(w, subcommands.FlagsCommand())
 	printCommandSummary(w, subcommands.CommandsCommand())
 	fmt.Fprintln(w)
 }
@@ -338,7 +292,7 @@ func main() {
 	subcommands.DefaultCommander.ExplainCommand = explainCommand
 
 	subcommands.Register(subcommands.HelpCommand(), "")
-	subcommands.Register(&flagsCmd{}, "")
+	subcommands.Register(subcommands.FlagsCommand(), "")
 	subcommands.Register(subcommands.CommandsCommand(), "")
 	subcommands.Register(&downloadCmd{}, "")
 	subcommands.Register(&progressCmd{}, "")


### PR DESCRIPTION
## Summary

Fix the Download Agent CLI help output so the generated help strings are clearer and match the actual command behavior.

This keeps the scope limited to help text and help rendering. It does not add tests or change command behavior.

## What changed

- Replaced the generic top-level help output with a Download Agent-specific overview.
- Updated the top-level description to reference the DNAnexus Platform.
- Fixed the `inspect -h` usage line so it no longer shows the `download` usage.
- Replaced the old `inspect` synopsis with clearer integrity-validation wording.
- Updated the `inspect` flag description to say `validating files` instead of `downloading files`.
- Improved subcommand help formatting so the usage line, synopsis, and flags are separated cleanly.
- Added clearer synopsis output for `commands -h`, `flags -h`, `progress -h`, and `version -h`.

## Before and after examples

### `dx-download-agent -h`

Before:

```text
Usage: dx-download-agent-old <flags> <subcommand> <subcommand args>

Subcommands:
        commands         list all command names
        download         Download files in a manifest
        flags            describe all known top-level flags
        help             describe subcommands and their syntax
        inspect          Inspect files downloaded in a manifest + additional 'health' checks
        progress         show current download progress
        version          get the version
```

After:

```text
dx-download-agent v0.6.3
CLI tool to manage the download of files from the DNAnexus Platform

Usage:
  dx-download-agent download [-num_threads=N] <manifest.json.bz2>
  dx-download-agent inspect [-num_threads=N] <manifest.json.bz2>
  dx-download-agent progress <manifest.json.bz2>
  dx-download-agent version

Authentication:
  Set DX_API_TOKEN or configure ~/.dnanexus_config/environment.json.

Primary commands:
  download        Download files in a manifest
  inspect         Inspect files downloaded in a manifest and validate their integrity
  progress        Show current download progress

Reference commands:
  version         Get the version
  help            describe subcommands and their syntax
  flags           describe all known top-level flags
  commands        list all command names
```

### `dx-download-agent commands -h`

Before:

```text
commands:
        Print a list of all commands.
```

After:

```text
commands:
        Print a list of all commands.

list all command names
```

### `dx-download-agent flags -h`

Before:

```text
flags [<subcommand>]:
        With an argument, print all flags of <subcommand>. Else,
        print a description of all known top-level flags.  (The basic
        help information only discusses the most generally important
        top-level flags.)
```

After:

```text
flags [<subcommand>]:
        With an argument, print all flags of <subcommand>. Else,
        print a description of all known top-level flags.  (The basic
        help information only discusses the most generally important
        top-level flags.)

describe all known top-level flags
```

### `dx-download-agent download -h`

Before:

```text
dx-download-agent download [-num_threads=N] <manifest.json.bz2>  -gc_info
        report statistics for golang garbage collection
  -max_threads int
        An alias for num_threads
  -num_threads int
        Number of threads to use when downloading files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.
  -verbose
        verbose logging
```

After:

```text
dx-download-agent download [-num_threads=N] <manifest.json.bz2>

Download files in a manifest

  -gc_info
      report statistics for golang garbage collection
  -max_threads int
      An alias for num_threads
  -num_threads int
      Number of threads to use when downloading files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.
  -verbose
      verbose logging
```

### `dx-download-agent inspect -h`

Before:

```text
dx-download-agent download [-num_threads=N] <manifest.json.bz2>  -num_threads int
        Number of threads to use when downloading files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.
  -verbose
        verbose logging
```

After:

```text
dx-download-agent inspect [-num_threads=N] <manifest.json.bz2>

Inspect files downloaded in a manifest and validate their integrity

  -num_threads int
      Number of threads to use when validating files. By default (or if zero), this number is chosen according to machine memory and CPU constraints.
  -verbose
      verbose logging
```

### `dx-download-agent progress -h`

Before:

```text
dx-download-agent progress <manifest.json.bz2>
```

After:

```text
dx-download-agent progress <manifest.json.bz2>

Show current download progress
```

### `dx-download-agent version -h`

Before:

```text
get the dx-download-agent version
```

After:

```text
dx-download-agent version

Get the version
```

## Validation

- Built the current branch and upstream `master` binaries locally and compared the main help-producing commands side by side.
- Ran `go test ./...` in an isolated HOME/PATH environment to avoid local DNAnexus config leaking into existing tests.
